### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,12 @@
+name: Test & Code-style
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
This workflow runs `npm test` on every _push_ and _pull request_ in our repo. It uses Node.js 12. Maybe in the future we can test it against different versions of Node.js (as `tox` does in Python world), but I am not sure how to achieve that in Node.js world yet.

Just as a reminder, `npm test` is mapped to [run tests with `ava`](https://github.com/datopian/jsv/blob/69d04c3d13967fdc2b24370c3a3112a7808aba60/package.json#L20) and to [check code style with `prettier`](https://github.com/datopian/jsv/blob/69d04c3d13967fdc2b24370c3a3112a7808aba60/package.json#L21).