### PR TITLE
Implement HTML as an output option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test & Code-style
+name: Build
 on: [push, pull_request]
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSON Schema Viewer
 
-JSON Schema viewer is a lightweight library and tool in JavaScript to turn a [JSON Schema](https://json-schema.org/) into a nice human readable document that you publish or embed in HTML or MarkDown.
+JSON Schema viewer is a lightweight library and tool in JavaScript to turn a [JSON Schema](https://json-schema.org/) into nice human-readable documents that you publish or embed in HTML or MarkDown.
 
 It is designed for use in rendering documentation for metadata and data schemas for data management systems like [CKAN](https://github.com/ckan/ckan) — though it can be used for any JSON Schema.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ visualization in MarkDown, unless another format is passed using --output.
 
 Options:
   -V, --version          output the version number
-  -p, --output <format>  Format of the output: md (default: "md")
+  -o, --output <format>  Format of the output: md (default: "md")
   -h, --help             display help for command
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build](https://github.com/datopian/jsv/workflows/Build/badge.svg)
+
 # JSON Schema Viewer
 
 JSON Schema viewer is a lightweight library and tool in JavaScript to turn a [JSON Schema](https://json-schema.org/) into nice human-readable documents that you publish or embed in HTML or MarkDown.
@@ -12,11 +14,18 @@ Requires [NodeJS](https://nodejs.org/en/) 12+:
 $ npm install
 ```
 
-If you want to have `jsv` available _globally_ in your path, you can use `npm link`.
+If you want to have `jsv` available _globally_ in your path, you can use `npm link` and use it from the terminal:
 
-## Usage
+```console
+$ jsv '{"$schema": "http://json-schema.org/draft-04/schema#", "title": "Data Resource", "description": "Data Resource.", "type": "object"}'
+# Data Resource
 
-### CLI
+**(`object`)**
+
+Data Resource.
+```
+
+## CLI
 
 ```console
 $ jsv --help
@@ -36,20 +45,9 @@ Options:
   -h, --help             display help for command
 ```
 
-#### Examples
+### Examples
 
-##### Passing the JSON Schema directly
-
-```console
-$ jsv '{"$schema": "http://json-schema.org/draft-04/schema#", "title": "Data Resource", "description": "Data Resource.", "type": "object"}'
-# Data Resource
-
-**(`object`)**
-
-Data Resource.
-```
-
-##### Piping with a local file
+#### Piping with a local file
 
 ```console
 $ cat test/fixtures/data-resource.json | jsv
@@ -67,7 +65,7 @@ The profile of this descriptor.
 …
 ```
 
-##### Piping from a remote file
+#### Piping from a remote file
 
 ```console
 $ curl https://specs.frictionlessdata.io/schemas/data-resource.json | jsv
@@ -85,11 +83,11 @@ The profile of this descriptor.
 …
 ```
 
-### API
+## API
 
 The `engine` async function expects the JSON Schema and a format, both as _string_. It returns the converted contents also as _string_.
 
-#### Example
+### Example
 
 To convert a given JSON schema from a file, we need to read the content of the input file pass it to the `engine`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -498,8 +498,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "chalk": {
       "version": "4.1.0",
@@ -735,8 +734,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -966,8 +964,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -1646,7 +1643,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -1672,8 +1668,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "6.5.0",
@@ -1923,14 +1918,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.17.0",
@@ -2034,8 +2027,148 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "showdown": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+      "requires": {
+        "yargs": "^14.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -2346,8 +2479,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "widest-line": {
       "version": "3.1.0",
@@ -2396,8 +2528,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "commander": "^6.0.0",
-    "nunjucks": "^3.2.2"
+    "nunjucks": "^3.2.2",
+    "showdown": "^1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsv",
   "version": "0.0.1",
   "main": "./src/render.js",
-  "description": "JSON Schema viewer is a lightweight javascript library and tool that turns JSON schemas into a elegant human readable documents.",
+  "description": "JSON Schema viewer is a lightweight javascript library and tool that turns JSON schemas into elegant human-readable documents.",
   "homepage": "https://github.com/datopian/jsv#readme",
   "license": "MIT",
   "type": "module",

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,7 @@ const pkg = require("../package.json");
 const doc = `jsv (JSON Scheme Viewer)
 
 JSON Schema viewer is a lightweight javascript library and tool that turns JSON
-schemas into a elegant human readable documents.
+schemas into elegant human-readable documents.
 
 It expects a JSON Schema from stdin and outputs to stdout its version for
 visualization in MarkDown, unless another format is passed using --output.`;

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,7 +21,7 @@ const main = () => {
     .version(pkg.version)
     .description(doc)
     .arguments("[<json>]")
-    .option("-p, --output <format>", `Format of the output: ${available}`, "md")
+    .option("-o, --output <format>", `Format of the output: ${available}`, "md")
     .action((json, options) =>
       engine(stdin || json, options.output)
         .then(console.log)

--- a/src/render.js
+++ b/src/render.js
@@ -2,19 +2,22 @@ import { dirname } from "path";
 import { fileURLToPath } from "url";
 
 import nunjucks from "nunjucks";
+import showdown from "showdown";
 
 import { removeExtraEmptyLines } from "./text.js";
 
 // load converters & template engines
 const srcDir = dirname(fileURLToPath(import.meta.url));
+const sd = new showdown.Converter();
 const env = new nunjucks.Environment(new nunjucks.FileSystemLoader(srcDir));
 env.addFilter("parseJson", JSON.parse);
 
 /// basic convertion functions
 const toMarkDown = (schema) => env.render("template.md", schema);
+const toHtml = (schema) => sd.makeHtml(toMarkDown(schema));
 
 // helpers for the engine function below
-const engines = { md: toMarkDown };
+const engines = { html: toHtml, md: toMarkDown };
 const available = Object.keys(engines).join(", ");
 
 // helper function to switch between different rendering engines/formats

--- a/test/fixtures/data-resource.html
+++ b/test/fixtures/data-resource.html
@@ -1,0 +1,107 @@
+<h1 id="dataresource">Data Resource</h1>
+<p><strong>(<code>object</code>)</strong></p>
+<p>Data Resource.</p>
+<h2 id="profile">Profile</h2>
+<p><strong>(<code>string</code>)</strong> Defaults to <em>data-resource</em>.</p>
+<p>The profile of this descriptor.</p>
+<p>Every Package and Resource descriptor has a profile. The default profile, if none is declared, is <code>data-package</code> for Package and <code>data-resource</code> for Resource.</p>
+<h3 id="examples">Examples</h3>
+<ul>
+<li><p><code>{"profile":"tabular-data-package"}</code></p></li>
+<li><p><code>{"profile":"http://example.com/my-profiles-json-schema.json"}</code></p></li>
+</ul>
+<h2 id="name">Name</h2>
+<p><strong>(<code>string</code>)</strong> </p>
+<p>An identifier string. Lower case characters with <code>.</code>, <code>_</code>, <code>-</code> and <code>/</code> are allowed.</p>
+<p>This is ideally a url-usable and human-readable name. Name <code>SHOULD</code> be invariant, meaning it <code>SHOULD NOT</code> change when its parent descriptor is updated.</p>
+<h3 id="example">Example</h3>
+<ul>
+<li><code>{"name":"my-nice-name"}</code></li>
+</ul>
+<h2 id="path">Path</h2>
+<p>A reference to the data for this resource, as either a path as a string, or an array of paths as strings. of valid URIs.</p>
+<p>The dereferenced value of each referenced data source in <code>path</code> <code>MUST</code> be commensurate with a native, dereferenced representation of the data the resource describes. For example, in a <em>Tabular</em> Data Resource, this means that the dereferenced value of <code>path</code> <code>MUST</code> be an array.</p>
+<h3 id="examples-1">Examples</h3>
+<ul>
+<li><p><code>{"path":["file.csv","file2.csv"]}</code></p></li>
+<li><p><code>{"path":["http://example.com/file.csv","http://example.com/file2.csv"]}</code></p></li>
+<li><p><code>{"path":"http://example.com/file.csv"}</code></p></li>
+</ul>
+<h2 id="data">Data</h2>
+<p>Inline data for this resource.</p>
+<h2 id="schema">Schema</h2>
+<p><strong>(<code>object</code>)</strong> </p>
+<p>A schema for this resource.</p>
+<h2 id="title">Title</h2>
+<p><strong>(<code>string</code>)</strong> </p>
+<p>A human-readable title.</p>
+<h3 id="example-1">Example</h3>
+<ul>
+<li><code>{"title":"My Package Title"}</code></li>
+</ul>
+<h2 id="description">Description</h2>
+<p><strong>(<code>string</code>)</strong> </p>
+<p>A text description. Markdown is encouraged.</p>
+<h3 id="example-2">Example</h3>
+<ul>
+<li><code>{"description":"# My Package description\nAll about my package."}</code></li>
+</ul>
+<h2 id="homepage">Home Page</h2>
+<p><strong>(<code>string</code>)</strong> </p>
+<p>The home on the web that is related to this data package.</p>
+<h3 id="example-3">Example</h3>
+<ul>
+<li><code>{"homepage":"http://example.com/"}</code></li>
+</ul>
+<h2 id="sources">Sources</h2>
+<p><strong>(<code>array</code>)</strong> </p>
+<p>The raw sources for this resource.</p>
+<h3 id="example-4">Example</h3>
+<ul>
+<li><code>{"sources":[{"title":"World Bank and OECD","path":"http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"}]}</code></li>
+</ul>
+<h2 id="licenses">Licenses</h2>
+<p><strong>(<code>array</code>)</strong> </p>
+<p>The license(s) under which the resource is published.</p>
+<p>This property is not legally binding and does not guarantee that the package is licensed under the terms defined herein.</p>
+<h3 id="example-5">Example</h3>
+<ul>
+<li><code>{"licenses":[{"name":"odc-pddl-1.0","path":"http://opendatacommons.org/licenses/pddl/","title":"Open Data Commons Public Domain Dedication and License v1.0"}]}</code></li>
+</ul>
+<h2 id="format">Format</h2>
+<p><strong>(<code>string</code>)</strong> </p>
+<p>The file format of this resource.</p>
+<p><code>csv</code>, <code>xls</code>, <code>json</code> are examples of common formats.</p>
+<h3 id="example-6">Example</h3>
+<ul>
+<li><code>{"format":"xls"}</code></li>
+</ul>
+<h2 id="mediatype">Media Type</h2>
+<p><strong>(<code>string</code>)</strong> </p>
+<p>The media type of this resource. Can be any valid media type listed with <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>.</p>
+<h3 id="example-7">Example</h3>
+<ul>
+<li><code>{"mediatype":"text/csv"}</code></li>
+</ul>
+<h2 id="encoding">Encoding</h2>
+<p><strong>(<code>string</code>)</strong> Defaults to <em>utf-8</em>.</p>
+<p>The file encoding of this resource.</p>
+<h3 id="example-8">Example</h3>
+<ul>
+<li><code>{"encoding":"utf-8"}</code></li>
+</ul>
+<h2 id="bytes">Bytes</h2>
+<p><strong>(<code>integer</code>)</strong> </p>
+<p>The size of this resource in bytes.</p>
+<h3 id="example-9">Example</h3>
+<ul>
+<li><code>{"bytes":2082}</code></li>
+</ul>
+<h2 id="hash">Hash</h2>
+<p><strong>(<code>string</code>)</strong> </p>
+<p>The MD5 hash of this resource. Indicate other hashing algorithms with the {algorithm}:{hash} format.</p>
+<h3 id="examples-2">Examples</h3>
+<ul>
+<li><p><code>{"hash":"d25c9c77f588f5dc32059d2da1136c02"}</code></p></li>
+<li><p><code>{"hash":"SHA256:5262f12512590031bbcc9a430452bfd75c2791ad6771320bb4b5728bfb78c4d0"}</code></p></li>
+</ul>

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -18,6 +18,16 @@ test("Can render a JSON schema to MarkDown", async (t) => {
     );
 });
 
+test("Can render a JSON schema to HTML", async (t) => {
+  const input = await readFixture("data-resource.json");
+  const expected = await readFixture("data-resource.html");
+  engine(input, "html")
+    .then((result) => t.is(result, expected))
+    .catch((error) =>
+      t.Fail(`Expected to render with no errors, but got:\n${error.message}`)
+    );
+});
+
 test("Engine throws an error when JSON is invalid", async (t) => {
   const input = await readFixture("invalid.json");
   engine(input, "md")
@@ -34,7 +44,8 @@ test("Engine throws an error when output format is invalid", async (t) => {
   engine(input, "go")
     .then(() => t.Fail("Expected a output format validation error."))
     .catch((error) => {
-      const expected = "go is not a valid output format. Options are: md.";
+      const expected =
+        "go is not a valid output format. Options are: html, md.";
       const result = error.message.substr(0, expected.length);
       t.is(result, expected);
     });


### PR DESCRIPTION
**Disclaimer**: This PR depends on #5 — its _diff_ includes #5's _diff_ and merging it will automatically merge #5 as well. It might be a good idea to review #5 before this one.

This implements the HTML output option using the `showdown` package to convert the existing Markdown to HTML. Now the CLI accepts `--output html` and the `engine` function accepts `"html"` as its second argument (which stands for `format` in the source code).

This new option is automatically added to the CLI's help:

```console
$ jsv --help
Usage: jsv [options] [<json>]

jsv (JSON Scheme Viewer)

JSON Schema viewer is a lightweight javascript library and tool that turns JSON
schemas into elegant human-readable documents.

It expects a JSON Schema from stdin and outputs to stdout its version for
visualization in MarkDown, unless another format is passed using --output.

Options:
  -V, --version          output the version number
  -p, --output <format>  Format of the output: html, md (default: "md")
  -h, --help             display help for command
```

And it can be testes with this simple example (included in the `README.md`):

```console
$ jsv --output html '{"$schema": "http://json-schema.org/draft-04/schema#", "title": "Data Resource", "description": "Data Resource.", "type": "object"}'
<h1 id="dataresource">Data Resource</h1>
<p><strong>(<code>object</code>)</strong></p>
<p>Data Resource.</p>
```
