### PR TITLE
Adds Python output and --template option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install
 If you want to have `jsv` available _globally_ in your path, you can use `npm link` and use it from the terminal:
 
 ```console
-$ jsv '{"$schema": "http://json-schema.org/draft-04/schema#", "title": "Data Resource", "description": "Data Resource.", "type": "object"}'
+$ jsv '{"title": "Data Resource", "description": "Data Resource.", "type": "object"}'
 # Data Resource
 
 **(`object`)**
@@ -34,15 +34,18 @@ Usage: jsv [options] [<json>]
 jsv (JSON Scheme Viewer)
 
 JSON Schema viewer is a lightweight javascript library and tool that turns JSON
-schemas into a elegant human readable documents.
+schemas into elegant human-readable documents.
 
 It expects a JSON Schema from stdin and outputs to stdout its version for
 visualization in MarkDown, unless another format is passed using --output.
+Alternatively, a custom Jinja2/Nunjucks template can be passed using --format
+(if --format is used, --output is ignored).
 
 Options:
-  -V, --version          output the version number
-  -o, --output <format>  Format of the output: md (default: "md")
-  -h, --help             display help for command
+  -V, --version              output the version number
+  -o, --output <format>      Format of the output: html, md (default: "md")
+  -t, --template <template>  Template to use for rendering
+  -h, --help                 display help for command
 ```
 
 ### Examples
@@ -83,6 +86,34 @@ The profile of this descriptor.
 …
 ```
 
+#### Exporting in HTML
+
+```console
+$ curl https://specs.frictionlessdata.io/schemas/data-resource.json | jsv --output html
+<h1 id="dataresource">Data Resource</h1>
+<p><strong>(<code>object</code>)</strong></p>
+<p>Data Resource.</p>
+<h2 id="profile">Profile</h2>
+<p><strong>(<code>string</code>)</strong> Defaults to <em>data-resource</em>.</p>
+<p>The profile of this descriptor.</p>
+…
+```
+
+#### Using a custom template
+
+For example, having this `custom.md` template:
+
+```markdown
+**{{ title }}** `{{ type }}`
+```
+
+One can have:
+
+```console
+$ jsv --template custom.md '{"title": "Data Resource", "type": "object"}'
+**Data Resource** `object`
+```
+
 ## API
 
 The `engine` async function expects the JSON Schema and a format, both as _string_. It returns the converted contents also as _string_.
@@ -97,7 +128,7 @@ import { engine } from "jsv";
 
 fs.promises
   .readFile("schema.json", "utf8")
-  .then((data) => engine(data, "md").then(console.log));
+  .then((data) => engine(data, { output: "md" }).then(console.log));
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Alternatively, a custom Jinja2/Nunjucks template can be passed using --format
 
 Options:
   -V, --version              output the version number
-  -o, --output <format>      Format of the output: html, md (default: "md")
+  -o, --output <format>      Format of the output: html, md, py (default: "md")
   -t, --template <template>  Template to use for rendering
   -h, --help                 display help for command
 ```
@@ -86,7 +86,7 @@ The profile of this descriptor.
 …
 ```
 
-#### Exporting in HTML
+#### Exporting to HTML
 
 ```console
 $ curl https://specs.frictionlessdata.io/schemas/data-resource.json | jsv --output html
@@ -96,6 +96,19 @@ $ curl https://specs.frictionlessdata.io/schemas/data-resource.json | jsv --outp
 <h2 id="profile">Profile</h2>
 <p><strong>(<code>string</code>)</strong> Defaults to <em>data-resource</em>.</p>
 <p>The profile of this descriptor.</p>
+…
+```
+
+#### Exporting to Python
+
+```console
+$ curl https://specs.frictionlessdata.io/schemas/data-resource.json | jsv --output py
+dataset_metadata = {
+    "profile": "data-resource",  # The profile of this descriptor.
+    # [example] "profile": "tabular-data-package"
+    # [example] "profile": "http://example.com/my-profiles-json-schema.json"
+    "name": "my-nice-name",  # An identifier string. Lower case characters with `.`, `_`, `-` and `/` are allowed.
+    "path": ["file.csv","file2.csv"],  # A reference to the data for this resource, as either a path as a string, or an array of paths as strings. of valid URIs.
 …
 ```
 
@@ -114,6 +127,8 @@ $ jsv --template custom.md '{"title": "Data Resource", "type": "object"}'
 **Data Resource** `object`
 ```
 
+Check the [custom templates section](#custom-templates) for more details.
+
 ## API
 
 The `engine` async function expects the JSON Schema and a format, both as _string_. It returns the converted contents also as _string_.
@@ -130,6 +145,70 @@ fs.promises
   .readFile("schema.json", "utf8")
   .then((data) => engine(data, { output: "md" }).then(console.log));
 ```
+
+Also you can use a [custom template](#custom-templates):
+
+```javascript
+engine(data, { template: "path/to/custom/template.r" });
+```
+
+## Custom templates
+
+`jsv` accepts custom templates processed by [Nunjucks](https://mozilla.github.io/nunjucks/) (a JavaScript port of [Jinja](https://jinja.palletsprojects.com/)). In additional to its natives filters, `jsv` added a couple of extra ones for better dealing with JSON Schema:
+
+### `cleanExample`
+
+The `examples` in JSON Schemas are a list of strings containing the key of that instance and an example of its possible value. This filter extracts just the value.
+
+For example, given `obj = { "example": 42 }`, `{{ obj|cleanExample }}` prints `42`.
+
+### `getDefault`
+
+This filter takes a JSON Schema _instance_ and try to gets its default value for visualization purposes:
+
+- If a default is given in the schema, this is the output
+
+- If there's no default, it tries to return the value of the first example
+
+- Otherwise, it returns `null`
+
+For example, given:
+
+```javascript
+a = { default: 42 };
+b = { examples: ['{ "answer": 42 }', '{ "answer": 21 }'] };
+c = {};
+```
+
+Then `{{ a|getDefault }}, {{ b|getDefault }}, {{ c|getDefault }}` prints `42, 42, null`
+
+### `getDescription`
+
+This filter takes a JSON Schema _instance_ and try to gets its description for visualization purposes:
+
+- If a description is given in the schema, this is the output
+
+- If there's no description, it tries to return the title instead
+
+- Otherwise, it returns `null`
+
+For example, given:
+
+```javascript
+a = { description: "42" };
+b = { name: "42" };
+c = {};
+```
+
+Then `{{ a|getDefault }}, {{ b|getDefault }}, {{ c|getDefault }}` prints `"42", "42", null`
+
+### `parseJson`
+
+A shorcut to JavaScript's native `JSON.parse`. Useful to parse strings that contains JSON data, as in the examples of JSON Schema, for instance.
+
+### `stringify`
+
+A shorcut to JavaScript's native `JSON.stringify`. Useful to parse JavaScript objects as strings in a template..
 
 ## Tests
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,17 @@ JSON Schema viewer is a lightweight javascript library and tool that turns JSON
 schemas into elegant human-readable documents.
 
 It expects a JSON Schema from stdin and outputs to stdout its version for
-visualization in MarkDown, unless another format is passed using --output.`;
+visualization in MarkDown, unless another format is passed using --output.
+Alternatively, a custom Jinja2/Nunjucks template can be passed using --format
+(if --format is used, --output is ignored).`;
+
+const run = (input, options) => {
+  // if template was provided, clean up the default output
+  if (options.template !== null) {
+    options.output = null;
+  }
+  engine(input, options).then(console.log).catch(console.error);
+};
 
 const main = () => {
   let stdin = "";
@@ -22,11 +32,8 @@ const main = () => {
     .description(doc)
     .arguments("[<json>]")
     .option("-o, --output <format>", `Format of the output: ${available}`, "md")
-    .action((json, options) =>
-      engine(stdin || json, options.output)
-        .then(console.log)
-        .catch(console.error)
-    );
+    .option("-t, --template <template>", "Template to use for rendering")
+    .action((json, options) => run(stdin || json, options));
 
   // input is available right away
   if (process.stdin.isTTY) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,8 +18,8 @@ Alternatively, a custom Jinja2/Nunjucks template can be passed using --format
 
 const run = (input, options) => {
   // if template was provided, clean up the default output
-  if (options.template !== null) {
-    options.output = null;
+  if (options.template !== undefined) {
+    options.output = undefined;
   }
   engine(input, options).then(console.log).catch(console.error);
 };

--- a/src/engines.js
+++ b/src/engines.js
@@ -5,13 +5,16 @@ import { fileURLToPath } from "url";
 import nunjucks from "nunjucks";
 import showdown from "showdown";
 
-const templateEngine = (schema, template = null) => {
+import { cleanExample, getDefault, getDescription } from "../src/filters.js";
+import { removeEmptyLines, removeExtraEmptyLines } from "./text.js";
+
+const getRenderer = (template = null, output = null) => {
+  const srcDir = path.dirname(fileURLToPath(import.meta.url));
   let templateName = "";
   let templateDir = "";
-  const srcDir = path.dirname(fileURLToPath(import.meta.url));
 
   if (template === null) {
-    templateName = "base.md";
+    templateName = `base.${output}`;
     templateDir = path.join(srcDir, "templates");
   } else {
     templateName = path.basename(template);
@@ -20,15 +23,51 @@ const templateEngine = (schema, template = null) => {
 
   const loader = new nunjucks.FileSystemLoader(templateDir);
   const env = new nunjucks.Environment(loader);
-  env.addFilter("parseJson", JSON.parse); // TODO document filter for custom templates
-  return env.render(templateName, schema);
+
+  env.addFilter("cleanExample", cleanExample);
+  env.addFilter("getDefault", getDefault);
+  env.addFilter("getDescription", getDescription);
+  env.addFilter("parseJson", JSON.parse);
+  env.addFilter("stringify", JSON.stringify);
+
+  return (schema) => env.render(templateName, schema);
+};
+
+const templateEngine = (
+  schema,
+  { template = null, output = "md", postRender = [] } = {}
+) => {
+  const render = getRenderer(template, output);
+  let result = render(schema);
+
+  // make sure post-render is an array (pipeline of transformations)
+  if (!Array.isArray(postRender)) {
+    postRender = [postRender];
+  }
+
+  // inject default post-render functions
+  if (output === "md") {
+    postRender.push(removeExtraEmptyLines);
+  }
+  if (output === "py") {
+    postRender.push(removeEmptyLines);
+  }
+
+  // run post-render functions
+  for (var idx = 0; idx < postRender.length; idx++) {
+    result = postRender[idx](result);
+  }
+
+  return result;
+};
+
+const md2html = (md) => {
+  const sd = new showdown.Converter();
+  return sd.makeHtml(md);
 };
 
 const toMarkDown = (schema) => templateEngine(schema);
+const toHtml = (schema) => templateEngine(schema, { postRender: md2html });
+const toPython = (schema) => templateEngine(schema, { output: "py" });
 
-const toHtml = (schema) => {
-  const sd = new showdown.Converter();
-  return sd.makeHtml(toMarkDown(schema));
-};
-
-export { templateEngine, toHtml, toMarkDown };
+export { templateEngine, toHtml, toMarkDown, toPython };

--- a/src/engines.js
+++ b/src/engines.js
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import nunjucks from "nunjucks";
+import showdown from "showdown";
+
+const templateEngine = (schema, template = null) => {
+  let templateName = "";
+  let templateDir = "";
+  const srcDir = path.dirname(fileURLToPath(import.meta.url));
+
+  if (template === null) {
+    templateName = "base.md";
+    templateDir = path.join(srcDir, "templates");
+  } else {
+    templateName = path.basename(template);
+    templateDir = path.dirname(template);
+  }
+
+  const loader = new nunjucks.FileSystemLoader(templateDir);
+  const env = new nunjucks.Environment(loader);
+  env.addFilter("parseJson", JSON.parse); // TODO document filter for custom templates
+  return env.render(templateName, schema);
+};
+
+const toMarkDown = (schema) => templateEngine(schema);
+
+const toHtml = (schema) => {
+  const sd = new showdown.Converter();
+  return sd.makeHtml(toMarkDown(schema));
+};
+
+export { templateEngine, toHtml, toMarkDown };

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,0 +1,31 @@
+const parse = (obj) => {
+  try {
+    return JSON.parse(obj);
+  } catch (err) {
+    throw new Error(`Invalid JSON example.\n${err}`);
+  }
+};
+
+// get the value of an JSON Schema example
+const cleanExample = (obj) => {
+  const parsed = parse(obj);
+  for (let key in parsed) {
+    return parsed[key];
+  }
+};
+
+// gets default value of a JSON Schema instance, falls back to the 1st example
+const getDefault = (obj) => {
+  if (obj.default !== undefined) {
+    return obj.default;
+  }
+
+  if (obj.examples === undefined || obj.examples.length < 1) {
+    return null;
+  }
+  return cleanExample(obj.examples[0]);
+};
+
+const getDescription = (obj) => obj.description || obj.name || null;
+
+export { cleanExample, getDefault, getDescription };

--- a/src/render.js
+++ b/src/render.js
@@ -1,9 +1,8 @@
 import fs from "fs";
 
-import { removeExtraEmptyLines } from "./text.js";
-import { templateEngine, toHtml, toMarkDown } from "./engines.js";
+import { templateEngine, toHtml, toMarkDown, toPython } from "./engines.js";
 
-const engines = { html: toHtml, md: toMarkDown };
+const engines = { html: toHtml, md: toMarkDown, py: toPython };
 const available = Object.keys(engines).join(", ");
 
 // helper function to validade engine's options
@@ -39,15 +38,13 @@ const validateJson = (input) => {
 const engine = async (input, { template = null, output = null } = {}) => {
   validateOptions({ template: template, output: output });
   const schema = validateJson(input);
-  let converted = "";
 
   if (output !== null) {
-    converted = engines[output](schema);
-  } else if (template !== null) {
-    converted = templateEngine(schema, template);
+    return engines[output](schema);
   }
-
-  return removeExtraEmptyLines(converted);
+  if (template !== null) {
+    return templateEngine(schema, { template: template });
+  }
 };
 
 export { available, engine };

--- a/src/render.js
+++ b/src/render.js
@@ -1,44 +1,52 @@
-import path from "path";
-import { fileURLToPath } from "url";
-
-import nunjucks from "nunjucks";
-import showdown from "showdown";
+import fs from "fs";
 
 import { removeExtraEmptyLines } from "./text.js";
+import { templateEngine, toHtml, toMarkDown } from "./engines.js";
 
-// load converters & template engines
-const srcDir = path.dirname(fileURLToPath(import.meta.url));
-const templateDir = path.join(srcDir, "templates");
-const sd = new showdown.Converter();
-const loader = new nunjucks.FileSystemLoader(templateDir);
-const env = new nunjucks.Environment(loader);
-env.addFilter("parseJson", JSON.parse);
-
-/// basic convertion functions
-const toMarkDown = (schema) => env.render("base.md", schema);
-const toHtml = (schema) => sd.makeHtml(toMarkDown(schema));
-
-// helpers for the engine function below
 const engines = { html: toHtml, md: toMarkDown };
 const available = Object.keys(engines).join(", ");
 
-// helper function to switch between different rendering engines/formats
-const engine = async (input, format) => {
-  let errorMsg = "";
-  if (!(format in engines)) {
-    errorMsg = `${format} is not a valid output format. Options are: ${available}.`;
-    throw new Error(errorMsg);
+// helper function to validade engine's options
+const validateOptions = ({ template = null, output = null }) => {
+  if (output === null && template === null) {
+    throw new Error("The engine needs an output or a template.");
   }
 
+  if (output !== null && template !== null) {
+    throw new Error("The engine needs an output or a template (not both).");
+  }
+
+  if (output !== null && !(output in engines)) {
+    throw new Error(`${output} is not valid. Options are: ${available}.`);
+  }
+
+  if (template !== null && !fs.existsSync(template)) {
+    throw new Error(`Could not find the template: ${template}.`);
+  }
+};
+
+const validateJson = (input) => {
   let schema = {};
   try {
     schema = JSON.parse(input);
   } catch (err) {
-    errorMsg = `Invalid JSON input.\n${err}`;
-    throw new Error(errorMsg);
+    throw new Error(`Invalid JSON input.\n${err}`);
+  }
+  return schema;
+};
+
+// helper function to switch between different rendering engines/formats
+const engine = async (input, { template = null, output = null } = {}) => {
+  validateOptions({ template: template, output: output });
+  const schema = validateJson(input);
+  let converted = "";
+
+  if (output !== null) {
+    converted = engines[output](schema);
+  } else if (template !== null) {
+    converted = templateEngine(schema, template);
   }
 
-  const converted = engines[format](schema);
   return removeExtraEmptyLines(converted);
 };
 

--- a/src/templates/base.py
+++ b/src/templates/base.py
@@ -1,0 +1,10 @@
+dataset_metadata = {
+{% for key, property in properties  %}
+    "{{ key }}": {{ property|getDefault|stringify|safe|replace("null", "None") }},{% if property|getDescription %}  # {{ property|getDescription }}{% endif %}
+    {% for example in property.examples %}
+    {% if not loop.first or property.default %}
+    # [example] "{{ key }}": {{ example|cleanExample|stringify|safe }}
+    {% endif %}
+    {% endfor %}
+{% endfor %}
+}

--- a/src/templates/macros.md
+++ b/src/templates/macros.md
@@ -1,6 +1,8 @@
 {% macro instance(property, level=2) %}
 
+{% if property.title %}
 {{ "#".repeat(level) }} {{ property.title }}
+{% endif %}
 
 {% if property.type %}**(`{{ property.type }}`)**{% endif %}{% if property.default %} Defaults to _{{ property.default }}_.{% endif %}
 

--- a/src/text.js
+++ b/src/text.js
@@ -1,9 +1,26 @@
-function removeExtraEmptyLines(text) {
+const rtrim = (text) => text.replace(/\s+$/, "");
+
+const removeEmptyLines = (text) => {
   const lines = text.split("\n");
   const cleaned = [];
 
   for (let idx = 0; idx < lines.length; idx++) {
-    let line = lines[idx].trim();
+    let line = rtrim(lines[idx]);
+    if (line == "") {
+      continue; // skip empty lines
+    }
+    cleaned.push(line);
+  }
+
+  return cleaned.join("\n").trim() + "\n";
+};
+
+const removeExtraEmptyLines = (text) => {
+  const lines = text.split("\n");
+  const cleaned = [];
+
+  for (let idx = 0; idx < lines.length; idx++) {
+    let line = rtrim(lines[idx]);
     let previous = cleaned[cleaned.length - 1] || "";
 
     if (line == "" && previous == "") {
@@ -13,6 +30,6 @@ function removeExtraEmptyLines(text) {
   }
 
   return cleaned.join("\n").trim() + "\n";
-}
+};
 
-export { removeExtraEmptyLines };
+export { removeEmptyLines, removeExtraEmptyLines };

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -1,0 +1,38 @@
+import test from "ava";
+
+import { cleanExample, getDefault, getDescription } from "../src/filters.js";
+
+test("cleanExample can show the value without the key", (t) => {
+  const input = '{ "example": 42 }';
+  t.is(cleanExample(input), 42);
+});
+
+test("getDefault can extract the default value when it exists", (t) => {
+  const input = { default: 42 };
+  t.is(getDefault(input), 42);
+});
+
+test("getDefault falls back to 1st example when default does not exist", (t) => {
+  const input = { examples: ['{ "answer": 42 }', '{ "answer": 21 }'] };
+  t.is(getDefault(input), 42);
+});
+
+test("getDefault returns null when nothing is found ", (t) => {
+  const input = {};
+  t.is(getDefault(input), null);
+});
+
+test("getDescription can extract the description value when it exists", (t) => {
+  const input = { description: "42" };
+  t.is(getDescription(input), "42");
+});
+
+test("getDescription falls back to name when description does not exist", (t) => {
+  const input = { name: "42" };
+  t.is(getDescription(input), "42");
+});
+
+test("getDescription returns null when nothing is found ", (t) => {
+  const input = {};
+  t.is(getDescription(input), null);
+});

--- a/test/fixtures/custom-template-output.md
+++ b/test/fixtures/custom-template-output.md
@@ -1,0 +1,5 @@
+# Data Resource
+
+**(`object`)**
+
+Data Resource.

--- a/test/fixtures/custom-template.md
+++ b/test/fixtures/custom-template.md
@@ -1,0 +1,5 @@
+# {{ title }}
+
+**(`{{ type }}`)**
+
+{{ description|safe }}

--- a/test/fixtures/data-resource.html
+++ b/test/fixtures/data-resource.html
@@ -32,7 +32,6 @@
 <li><p><code>{"path":"file.csv"}</code></p></li>
 <li><p><code>{"path":"http://example.com/file.csv"}</code></p></li>
 </ul>
-<h5 id=""> </h5>
 <p><strong>(<code>array</code>)</strong></p>
 <h6 id="examples-2">Examples</h6>
 <ul>

--- a/test/fixtures/data-resource.md
+++ b/test/fixtures/data-resource.md
@@ -54,8 +54,6 @@ Implementations need to negotiate the type of path provided, and dereference the
 
 - `{"path":"http://example.com/file.csv"}`
 
-#####
-
 **(`array`)**
 
 ###### Examples

--- a/test/fixtures/data-resource.py
+++ b/test/fixtures/data-resource.py
@@ -1,0 +1,23 @@
+dataset_metadata = {
+    "profile": "data-resource",  # The profile of this descriptor.
+    # [example] "profile": "tabular-data-package"
+    # [example] "profile": "http://example.com/my-profiles-json-schema.json"
+    "name": "my-nice-name",  # An identifier string. Lower case characters with `.`, `_`, `-` and `/` are allowed.
+    "path": ["file.csv","file2.csv"],  # A reference to the data for this resource, as either a path as a string, or an array of paths as strings. of valid URIs.
+    # [example] "path": ["http://example.com/file.csv","http://example.com/file2.csv"]
+    # [example] "path": "http://example.com/file.csv"
+    "data": None,  # Inline data for this resource.
+    "schema": None,  # A schema for this resource.
+    "title": "My Package Title",  # A human-readable title.
+    "description": "# My Package description\nAll about my package.",  # A text description. Markdown is encouraged.
+    "homepage": "http://example.com/",  # The home on the web that is related to this data package.
+    "sources": [{"title":"World Bank and OECD","path":"http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"}],  # The raw sources for this resource.
+    "licenses": [{"name":"odc-pddl-1.0","path":"http://opendatacommons.org/licenses/pddl/","title":"Open Data Commons Public Domain Dedication and License v1.0"}],  # The license(s) under which the resource is published.
+    "format": "xls",  # The file format of this resource.
+    "mediatype": "text/csv",  # The media type of this resource. Can be any valid media type listed with [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml).
+    "encoding": "utf-8",  # The file encoding of this resource.
+    # [example] "encoding": "utf-8"
+    "bytes": 2082,  # The size of this resource in bytes.
+    "hash": "d25c9c77f588f5dc32059d2da1136c02",  # The MD5 hash of this resource. Indicate other hashing algorithms with the {algorithm}:{hash} format.
+    # [example] "hash": "SHA256:5262f12512590031bbcc9a430452bfd75c2791ad6771320bb4b5728bfb78c4d0"
+}

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -32,6 +32,16 @@ test("Can render a JSON schema to HTML", async (t) => {
     );
 });
 
+test("Can render a JSON schema to Python", async (t) => {
+  const input = await readFixture("data-resource.json");
+  const expected = await readFixture("data-resource.py");
+  engine(input, { output: "py" })
+    .then((result) => t.is(result, expected))
+    .catch((error) =>
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
+    );
+});
+
 test("Can render using a custom template", async (t) => {
   const input = await readFixture("data-resource.json");
   const expected = await readFixture("custom-template-output.md");
@@ -57,7 +67,7 @@ test("Engine throws an error when output format is invalid", async (t) => {
   engine("sample input", { output: "go" })
     .then(() => t.fail("Expected a output format validation error."))
     .catch((error) => {
-      const expected = "go is not valid. Options are: html, md.";
+      const expected = "go is not valid. Options are: html, md, py.";
       const result = error.message.substr(0, expected.length);
       t.is(result, expected);
     });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -8,29 +8,43 @@ const readFixture = async (name) => {
   return await fs.promises.readFile("./test/fixtures/" + name, "utf8");
 };
 
+const showError = (error) => {
+  return `\n\n${error.message}\n\nTraceback:\n${error.stack}`;
+};
+
 test("Can render a JSON schema to MarkDown", async (t) => {
   const input = await readFixture("data-resource.json");
   const expected = await readFixture("data-resource.md");
-  engine(input, "md")
+  engine(input, { output: "md" })
     .then((result) => t.is(result, expected))
     .catch((error) =>
-      t.fail(`Expected to render with no errors, but got:\n${error.message}`)
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
     );
 });
 
 test("Can render a JSON schema to HTML", async (t) => {
   const input = await readFixture("data-resource.json");
   const expected = await readFixture("data-resource.html");
-  engine(input, "html")
+  engine(input, { output: "html" })
     .then((result) => t.is(result, expected))
     .catch((error) =>
-      t.fail(`Expected to render with no errors, but got:\n${error.message}`)
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
+    );
+});
+
+test("Can render using a custom template", async (t) => {
+  const input = await readFixture("data-resource.json");
+  const expected = await readFixture("custom-template-output.md");
+  engine(input, { template: "test/fixtures/custom-template.md" })
+    .then((result) => t.is(result, expected))
+    .catch((error) =>
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
     );
 });
 
 test("Engine throws an error when JSON is invalid", async (t) => {
   const input = await readFixture("invalid.json");
-  engine(input, "md")
+  engine(input, { output: "md" })
     .then(() => t.fail("Expected JSON validation error."))
     .catch((error) => {
       const expected = "Invalid JSON input.";
@@ -40,13 +54,58 @@ test("Engine throws an error when JSON is invalid", async (t) => {
 });
 
 test("Engine throws an error when output format is invalid", async (t) => {
-  const input = await readFixture("data-resource.json");
-  engine(input, "go")
+  engine("sample input", { output: "go" })
     .then(() => t.fail("Expected a output format validation error."))
     .catch((error) => {
-      const expected =
-        "go is not a valid output format. Options are: html, md.";
+      const expected = "go is not valid. Options are: html, md.";
       const result = error.message.substr(0, expected.length);
       t.is(result, expected);
+    });
+});
+
+test("Engine throws an error when template does not exist", async (t) => {
+  engine("sample input", { template: "this-should-not-exist.md" })
+    .then(() => t.fail("Expected a template not found error."))
+    .catch((error) => {
+      t.is(
+        error.message,
+        "Could not find the template: this-should-not-exist.md."
+      );
+    });
+});
+
+test("Engine throws an error when it has no output nor template", async (t) => {
+  engine("sample input", {})
+    .then(() =>
+      t.fail("Expected a missing output or template validation error.")
+    )
+    .catch((error) => {
+      t.is(error.message, "The engine needs an output or a template.");
+    });
+});
+
+test("Engine throws an error when it has no options", async (t) => {
+  engine("sample input")
+    .then(() =>
+      t.fail("Expected a missing output or template validation error.")
+    )
+    .catch((error) => {
+      t.is(error.message, "The engine needs an output or a template.");
+    });
+});
+
+test("Engine throws an error when it has both output and template", async (t) => {
+  engine("sample input", {
+    output: "html",
+    template: "this-should-not-exist.md",
+  })
+    .then(() =>
+      t.fail("Expected a missing output or template validation error.")
+    )
+    .catch((error) => {
+      t.is(
+        error.message,
+        "The engine needs an output or a template (not both)."
+      );
     });
 });

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -1,6 +1,12 @@
 import test from "ava";
 
-import { removeExtraEmptyLines } from "../src/text.js";
+import { removeEmptyLines, removeExtraEmptyLines } from "../src/text.js";
+
+test("Can clean up empty lines from a string", (t) => {
+  const expect = "0\n1\n2\n3\n4\n";
+  const result = removeEmptyLines("0\n\n  \n\n1\n\n\n2\n\n3\n4");
+  t.is(result, expect);
+});
 
 test("Can clean up extra empty lines from a string", (t) => {
   const expect = "0\n\n1\n\n2\n\n3\n4\n";


### PR DESCRIPTION
This PR implements the first two tasks described in #11, that is to say, the feature to use any given template and also to output as Python code:

[![asciicast](https://asciinema.org/a/pKRVpnMOApS7opDxjS1KFpLzu.svg)](https://asciinema.org/a/pKRVpnMOApS7opDxjS1KFpLzu)

The `README.md` was also updated with a Python example and a section on custom templates.

As these changes enhanced considerably the architecture of the package (for example, creatine a pipeline for template post-processing with `postRender`, adding custom template filters, changing the `engine`'s API) it might be easier to check the changes commit by commit for a more comprehensive understanding of the _diff_. In sum 3c93ad5 introduces a more robust architecture to allow us to easily render with any given template, and 791d901 uses this new architecture to implements Python as an output option.