### PR TITLE
Adds file flag, enabling users to read from files in a system path

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -33,6 +33,7 @@ const main = () => {
     .arguments("[<json>]")
     .option("-o, --output <format>", `Format of the output: ${available}`, "md")
     .option("-t, --template <template>", "Template to use for rendering")
+    .option("-f, --file <file>", "Read an existing JSON file")
     .action((json, options) => run(stdin || json, options));
 
   // input is available right away

--- a/src/render.js
+++ b/src/render.js
@@ -35,13 +35,21 @@ const validateJson = (input) => {
 };
 
 // helper function to switch between different rendering engines/formats
-const engine = async (input, { template = null, output = null } = {}) => {
+const engine = async (
+  input = null,
+  { template = null, output = null, file = null } = {}
+) => {
   validateOptions({ template: template, output: output });
+
+  if (file !== null && fs.existsSync(file)) {
+    input = fs.readFileSync(file);
+  }
   const schema = validateJson(input);
 
   if (output !== null) {
     return engines[output](schema);
   }
+
   if (template !== null) {
     return templateEngine(schema, { template: template });
   }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -119,3 +119,14 @@ test("Engine throws an error when it has both output and template", async (t) =>
       );
     });
 });
+
+test("Can read a JSON file with --file flag", async (t) => {
+  const file = "./test/fixtures/data-resource.json";
+  const expected = await readFixture("data-resource.md");
+  const input = null;
+  engine(input, { file: file, output: "md" })
+    .then((result) => t.is(result, expected))
+    .catch((error) =>
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
+    );
+});


### PR DESCRIPTION
Hey!

I was trying to use your tool as a way to read existing files in my s3-file system and thought that `cat file.json | jsv --output py` was not optimal.

In this pull request I created the flag `--file`, which enables users to read files directly from their system, like in the code below:

```
jsv --file test/fixtures/data-resource.json --output py
```