### PR TITLE
Adds CKAN Schema as a possible input

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,18 @@ jsv (JSON Scheme Viewer)
 JSON Schema viewer is a lightweight javascript library and tool that turns JSON
 schemas into elegant human-readable documents.
 
-It expects a JSON Schema from stdin and outputs to stdout its version for
-visualization in MarkDown, unless another format is passed using --output.
-Alternatively, a custom Jinja2/Nunjucks template can be passed using --format
-(if --format is used, --output is ignored).
+It expects a JSON or CKAN Schema from stdin (defaults to JSON Schema) and
+outputs to stdout its version for visualization in MarkDown (unless another
+format is passed using --output). Alternatively, a custom Jinja2/Nunjucks
+template can be passed using --template.
 
 Options:
   -V, --version              output the version number
-  -o, --output <format>      Format of the output: html, md, py (default: "md")
-  -t, --template <template>  Template to use for rendering
+  -i, --input <format>       Format of the input: json for JSON Schema, ckan
+                             for CKAN Schema (default: "json")
+  -o, --output <format>      Format of the output: html, json, md, py (default:
+                             "md")
+  -t, --template <template>  Template to use for rendering (overrides --output)
   -h, --help                 display help for command
 ```
 
@@ -112,6 +115,37 @@ dataset_metadata = {
 …
 ```
 
+#### Reading from a CKAN Schema input
+
+```console
+$ cat test/fixtures/ckan-schema.json | jsv --input ckan
+# BMGF&#39;s special metadatas
+
+**(`object`)**
+
+## Title
+
+**(`string`)**
+
+…
+```
+
+#### Converting from CKAN Schema to JSON Schema
+
+```console
+$ cat test/fixtures/ckan-schema.json | jsv --input ckan --output json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BMGF's special metadatas",
+  "type": "object",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string",
+      "propertyOrder": 1,
+…
+```
+
 #### Using a custom template
 
 For example, having this `custom.md` template:
@@ -133,7 +167,7 @@ Check the [custom templates section](#custom-templates) for more details.
 
 The `engine` async function expects the JSON Schema and a format, both as _string_. It returns the converted contents also as _string_.
 
-### Example
+### Examples
 
 To convert a given JSON schema from a file, we need to read the content of the input file pass it to the `engine`:
 
@@ -143,13 +177,21 @@ import { engine } from "jsv";
 
 fs.promises
   .readFile("schema.json", "utf8")
-  .then((data) => engine(data, { output: "md" }).then(console.log));
+  .then((data) =>
+    engine(data, { input: "json", output: "md" }).then(console.log)
+  );
 ```
 
 Also you can use a [custom template](#custom-templates):
 
 ```javascript
 engine(data, { template: "path/to/custom/template.r" });
+```
+
+And convert from CKAN to JSON Schema on the fly:
+
+```javascript
+engine(data, { input: "ckan", output: "json" }).then(console.log);
 ```
 
 ## Custom templates

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ jsv (JSON Scheme Viewer)
 JSON Schema viewer is a lightweight javascript library and tool that turns JSON
 schemas into elegant human-readable documents.
 
-It expects a JSON or CKAN Schema from stdin (defaults to JSON Schema) and
-outputs to stdout its version for visualization in MarkDown (unless another
+It expects a JSON or CKAN Schema (defaults to JSON Schema) from stdin, or a
+path to a file with that content.
+
+It outputs to stdout its version for visualization in MarkDown (unless another
 format is passed using --output). Alternatively, a custom Jinja2/Nunjucks
 template can be passed using --template.
 
@@ -53,10 +55,10 @@ Options:
 
 ### Examples
 
-#### Piping with a local file
+#### From a local file
 
 ```console
-$ cat test/fixtures/data-resource.json | jsv
+$ jsv test/fixtures/data-resource.json
 # Data Resource
 
 **(`object`)**
@@ -133,7 +135,7 @@ $ cat test/fixtures/ckan-schema.json | jsv --input ckan
 #### Converting from CKAN Schema to JSON Schema
 
 ```console
-$ cat test/fixtures/ckan-schema.json | jsv --input ckan --output json
+$ jsv --input ckan --output json test/fixtures/ckan-schema.json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "BMGF's special metadatas",
@@ -165,21 +167,23 @@ Check the [custom templates section](#custom-templates) for more details.
 
 ## API
 
-The `engine` async function expects the JSON Schema and a format, both as _string_. It returns the converted contents also as _string_.
+The `engine` async function expects the first argument to be:
+
+- a JSON Schema string
+- a path to a file containing a JSON Schema
+- (with the `--input ckan` flag) a CKAN Schema string
+- (with the `--input ckan` flag) a path to a file containing a CKAN Schema
+
+And the secont argument should be an object with `input`, `output` or `template` — as described in the CLI help.
 
 ### Examples
 
-To convert a given JSON schema from a file, we need to read the content of the input file pass it to the `engine`:
+To convert a given JSON schema from a file:
 
 ```javascript
-import fs from "fs";
 import { engine } from "jsv";
 
-fs.promises
-  .readFile("schema.json", "utf8")
-  .then((data) =>
-    engine(data, { input: "json", output: "md" }).then(console.log)
-  );
+engine("schema.json", { input: "json", output: "md" }).then(console.log);
 ```
 
 Also you can use a [custom template](#custom-templates):
@@ -191,7 +195,7 @@ engine(data, { template: "path/to/custom/template.r" });
 And convert from CKAN to JSON Schema on the fly:
 
 ```javascript
-engine(data, { input: "ckan", output: "json" }).then(console.log);
+engine(data, { input: "ckan", output: "json" });
 ```
 
 ## Custom templates

--- a/src/ckan.js
+++ b/src/ckan.js
@@ -1,0 +1,80 @@
+// given a CKAN Schema field, returns its label as string (choosing the first
+// of them if labels in more than one language are present)
+const getCkanFieldLabel = (field) => {
+  if (typeof field.label === "string") {
+    return field.label;
+  }
+
+  for (let key in field.label) {
+    return field.label[key];
+  }
+};
+
+const ckanFieldParser = (field, order = null) => {
+  let instance = {
+    title: getCkanFieldLabel(field),
+    type: "string", // TODO is there type annotations in CKAN?
+  };
+
+  if (order !== null) {
+    instance.propertyOrder = order;
+  }
+
+  if (field.help_text !== undefined) {
+    instance.description = field.help_text;
+  }
+
+  if (field.choices !== undefined) {
+    instance.examples = field.choices.map((choice) => {
+      let obj = {};
+      obj[field.field_name] = choice.value;
+      return JSON.stringify(obj);
+    });
+  }
+
+  if (field.preset === "date" || field.preset == "datetime") {
+    instance.format = field.preset.replace("time", "-time");
+  }
+
+  return instance;
+};
+
+const ckanToJsonSchema = (ckan) => {
+  const fields = ["dataset_fields", "resource_fields"];
+  let required = [];
+  let properties = [];
+  let count = 0;
+
+  for (let idx = 0; idx < fields.length; idx++) {
+    let fieldsList = ckan[fields[idx]];
+    for (let i = 0; i < fieldsList.length; i++) {
+      let field = fieldsList[i];
+      properties[field.field_name] = ckanFieldParser(field, count + 1);
+      if (field.required) {
+        required.push(field.field_name);
+      }
+      count++;
+    }
+  }
+
+  let json = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    title: ckan.about,
+    type: "object",
+  };
+
+  if (Object.keys(properties).length > 0) {
+    json.properties = {};
+    for (let key in properties) {
+      json.properties[key] = properties[key];
+    }
+  }
+
+  if (required.length > 0) {
+    json.required = required;
+  }
+
+  return json; // TODO implement parser for CKAN's choices_helper
+};
+
+export { ckanToJsonSchema };

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,8 +11,10 @@ const doc = `jsv (JSON Scheme Viewer)
 JSON Schema viewer is a lightweight javascript library and tool that turns JSON
 schemas into elegant human-readable documents.
 
-It expects a JSON or CKAN Schema from stdin (defaults to JSON Schema) and
-outputs to stdout its version for visualization in MarkDown (unless another
+It expects a JSON or CKAN Schema (defaults to JSON Schema) from stdin, or a
+path to a file with that content.
+
+It outputs to stdout its version for visualization in MarkDown (unless another
 format is passed using --output). Alternatively, a custom Jinja2/Nunjucks
 template can be passed using --template.`;
 
@@ -41,8 +43,6 @@ const main = () => {
       "-t, --template <template>",
       "Template to use for rendering (overrides --output)"
     )
-    .option("-t, --template <template>", "Template to use for rendering")
-    .option("-f, --file <file>", "Read an existing JSON file")
     .action((json, options) => run(stdin || json, options));
 
   // input is available right away

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,17 +11,17 @@ const doc = `jsv (JSON Scheme Viewer)
 JSON Schema viewer is a lightweight javascript library and tool that turns JSON
 schemas into elegant human-readable documents.
 
-It expects a JSON Schema from stdin and outputs to stdout its version for
-visualization in MarkDown, unless another format is passed using --output.
-Alternatively, a custom Jinja2/Nunjucks template can be passed using --format
-(if --format is used, --output is ignored).`;
+It expects a JSON or CKAN Schema from stdin (defaults to JSON Schema) and
+outputs to stdout its version for visualization in MarkDown (unless another
+format is passed using --output). Alternatively, a custom Jinja2/Nunjucks
+template can be passed using --template.`;
 
-const run = (input, options) => {
+const run = (json, options) => {
   // if template was provided, clean up the default output
   if (options.template !== undefined) {
     options.output = undefined;
   }
-  engine(input, options).then(console.log).catch(console.error);
+  engine(json, options).then(console.log).catch(console.error);
 };
 
 const main = () => {
@@ -31,8 +31,16 @@ const main = () => {
     .version(pkg.version)
     .description(doc)
     .arguments("[<json>]")
+    .option(
+      "-i, --input <format>",
+      "Format of the input: json for JSON Schema, ckan for CKAN Schema",
+      "json"
+    )
     .option("-o, --output <format>", `Format of the output: ${available}`, "md")
-    .option("-t, --template <template>", "Template to use for rendering")
+    .option(
+      "-t, --template <template>",
+      "Template to use for rendering (overrides --output)"
+    )
     .action((json, options) => run(stdin || json, options));
 
   // input is available right away

--- a/src/engines.js
+++ b/src/engines.js
@@ -3,6 +3,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 import nunjucks from "nunjucks";
+import prettier from "prettier";
 import showdown from "showdown";
 
 import { cleanExample, getDefault, getDescription } from "../src/filters.js";
@@ -69,5 +70,7 @@ const md2html = (md) => {
 const toMarkDown = (schema) => templateEngine(schema);
 const toHtml = (schema) => templateEngine(schema, { postRender: md2html });
 const toPython = (schema) => templateEngine(schema, { output: "py" });
+const toJson = (schema) =>
+  prettier.format(JSON.stringify(schema), { parser: "json" });
 
-export { templateEngine, toHtml, toMarkDown, toPython };
+export { templateEngine, toHtml, toJson, toMarkDown, toPython };

--- a/src/render.js
+++ b/src/render.js
@@ -6,7 +6,7 @@ import {
   toHtml,
   toJson,
   toMarkDown,
-  toPython
+  toPython,
 } from "./engines.js";
 
 const engines = { html: toHtml, json: toJson, md: toMarkDown, py: toPython };
@@ -35,12 +35,18 @@ const validateOptions = ({ input = null, output = null, template = null }) => {
   }
 };
 
-const validateJson = input => {
+const validateJson = (input) => {
   let schema = {};
+  if (fs.existsSync(input)) {
+    return validateJson(fs.readFileSync(input));
+  }
+
   try {
     schema = JSON.parse(input);
   } catch (err) {
-    throw new Error(`Invalid JSON input.\n${err}`);
+    throw new Error(
+      `Path points to a non-existent file, or it is an invalid JSON input.\n${err}`
+    );
   }
   return schema;
 };
@@ -48,18 +54,9 @@ const validateJson = input => {
 // helper function to switch between different rendering engines/formats
 const engine = async (
   content,
-  { input = null, output = null, template = null, file = null } = {}
+  { input = null, output = null, template = null } = {}
 ) => {
-  validateOptions({
-    input: input,
-    output: output,
-    template: template,
-    file: file
-  });
-
-  if (file !== null && fs.existsSync(file)) {
-    content = fs.readFileSync(file);
-  }
+  validateOptions({ input: input, output: output, template: template });
   let schema = validateJson(content);
   if (input === "ckan") {
     schema = ckanToJsonSchema(schema);

--- a/src/render.js
+++ b/src/render.js
@@ -1,12 +1,19 @@
 import fs from "fs";
 
-import { templateEngine, toHtml, toMarkDown, toPython } from "./engines.js";
+import { ckanToJsonSchema } from "./ckan.js";
+import {
+  templateEngine,
+  toHtml,
+  toJson,
+  toMarkDown,
+  toPython,
+} from "./engines.js";
 
-const engines = { html: toHtml, md: toMarkDown, py: toPython };
+const engines = { html: toHtml, json: toJson, md: toMarkDown, py: toPython };
 const available = Object.keys(engines).join(", ");
 
 // helper function to validade engine's options
-const validateOptions = ({ template = null, output = null }) => {
+const validateOptions = ({ input = null, output = null, template = null }) => {
   if (output === null && template === null) {
     throw new Error("The engine needs an output or a template.");
   }
@@ -22,6 +29,10 @@ const validateOptions = ({ template = null, output = null }) => {
   if (template !== null && !fs.existsSync(template)) {
     throw new Error(`Could not find the template: ${template}.`);
   }
+
+  if (output === "json" && input === "json") {
+    throw new Error("Input and output set to JSON, no transformation needed.");
+  }
 };
 
 const validateJson = (input) => {
@@ -35,9 +46,16 @@ const validateJson = (input) => {
 };
 
 // helper function to switch between different rendering engines/formats
-const engine = async (input, { template = null, output = null } = {}) => {
-  validateOptions({ template: template, output: output });
-  const schema = validateJson(input);
+const engine = async (
+  content,
+  { input = null, output = null, template = null } = {}
+) => {
+  validateOptions({ input: input, output: output, template: template });
+
+  let schema = validateJson(content);
+  if (input === "ckan") {
+    schema = ckanToJsonSchema(schema);
+  }
 
   if (output !== null) {
     return engines[output](schema);

--- a/test/fixtures/ckan-schema-as-json-schema.json
+++ b/test/fixtures/ckan-schema-as-json-schema.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BMGF's special metadatas",
+  "type": "object",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string",
+      "propertyOrder": 1,
+      "description": "A descriptive name given to the Dataset. This should be an intuitive labelling of the Dataset for search, sharing and linking."
+    },
+    "name": { "title": "Name", "type": "string", "propertyOrder": 40 },
+    "notes": { "title": "Description", "type": "string", "propertyOrder": 3 },
+    "tag_string": {
+      "title": "Tags",
+      "type": "string",
+      "propertyOrder": 4,
+      "description": "What labels the Dataset in question belongs to. Tags also allow for browsing between similarly tagged Datasets in addition to enabling better discoverability through tag search."
+    },
+    "license_id": {
+      "title": "License",
+      "type": "string",
+      "propertyOrder": 5,
+      "description": "Licenses makes it clear to users whether they have the rights to use, change and re-distribute the data. Definitions and additional information can be found at <a href=\"http://opendefinition.org/\" target=\"opendefinition.org\">http://opendefinition.org/</a>."
+    },
+    "owner_org": {
+      "title": "Organization",
+      "type": "string",
+      "propertyOrder": 6,
+      "description": "The Team to which the Dataset belongs."
+    },
+    "information_classification": {
+      "title": "Information classification",
+      "type": "string",
+      "propertyOrder": 7,
+      "description": "BMGF <a href=\"https://bmgf.sharepoint.com/:w:/r/sites/AzureCoP/_layouts/15/Doc.aspx?sourcedoc=%7BFFAA18FA-5297-45BE-B083-05BA6F5E925E%7D&file=Governance%20and%20Security%20-%20Information%20Classification%20Standard.docx&action=default&mobileredirect=true\" target=\"bmgf_pii\">Information Classification Standard</a>.",
+      "examples": [
+        "{\"information_classification\":\"public-public-external\"}",
+        "{\"information_classification\":\"not_sensitive-non_confidential-internal-business\"}",
+        "{\"information_classification\":\"not_sensitive-non_confidential-internal_limited_external-business\"}",
+        "{\"information_classification\":\"sensitive-confidential-internal_restricted-business\"}",
+        "{\"information_classification\":\"sensitive-confidential_third_party-internal_restricted-agreement\"}",
+        "{\"information_classification\":\"sensitive-regulated-internal_restricted-regulation\"}",
+        "{\"information_classification\":\"very_sensitive-highly_regulated-internal_highly_restricted-regulation\"}"
+      ]
+    },
+    "visibility": {
+      "title": "Visibility",
+      "type": "string",
+      "propertyOrder": 8,
+      "description": "The accessibility setting for the Dataset’s Resources, users can choose between the following: </br> <ul><li><b>Public</b>: Dataset’s Resources can be accessed by all users within the Foundation.</li><li><b>Restricted:</b> Restricted Datasets are visible to all foundation Users but can only be Explored (previewed or downloaded) by Members of the Team that the Dataset is associated with or Users that are Collaborators of the Dataset.</li></ul>",
+      "examples": [
+        "{\"visibility\":\"restricted\"}",
+        "{\"visibility\":\"public\"}"
+      ]
+    },
+    "private": {
+      "title": "Visibility (Private/Public)",
+      "type": "string",
+      "propertyOrder": 9,
+      "description": "HELP TEXT FOR VISIBILITY"
+    },
+    "maintainer": {
+      "title": "Maintainer",
+      "type": "string",
+      "propertyOrder": 10,
+      "description": "The individual responsible for maintaining the Dataset."
+    },
+    "maintainer_email": {
+      "title": "Maintainer",
+      "type": "string",
+      "propertyOrder": 11
+    },
+    "publisher": {
+      "title": "Publisher",
+      "type": "string",
+      "propertyOrder": 12,
+      "description": "An entity responsible for making the Dataset available. Examples of a Publisher include a person, an organization, or a service."
+    },
+    "temporal_coverage": {
+      "title": "Temporal coverage",
+      "type": "string",
+      "propertyOrder": 13,
+      "description": "The temporal topic of the Dataset. Temporal topic may be a named period, date, or date range."
+    },
+    "geographic_coverage": {
+      "title": "Geographic coverage",
+      "type": "string",
+      "propertyOrder": 14,
+      "description": "Geographical area where data was collected or place which is the subject of a collection, or a location which is the focus of the Dataset."
+    },
+    "geographic_level": {
+      "title": "Geographic level",
+      "type": "string",
+      "propertyOrder": 15,
+      "description": "The lowest level-of-detail/granularity of the Dataset along the geographic dimension.",
+      "examples": [
+        "{\"geographic_level\":\"global\"}",
+        "{\"geographic_level\":\"regional\"}",
+        "{\"geographic_level\":\"national\"}",
+        "{\"geographic_level\":\"sub_national\"}",
+        "{\"geographic_level\":\"other\"}"
+      ]
+    },
+    "language": {
+      "title": "Language",
+      "type": "string",
+      "propertyOrder": 16,
+      "description": "The language(s) of the Dataset."
+    },
+    "url": { "title": "URL", "type": "string", "propertyOrder": 39 },
+    "dataset_type": {
+      "title": "Type",
+      "type": "string",
+      "propertyOrder": 18,
+      "description": "The nature or genre of the Dataset. Users can choose between the following:</br> <ul><li><b>Survey:</b> An investigation about the characteristics of a given population by means of collecting data from a sample of that population.</li><li><b>Indicator: </b>Data that represents the measurement of something (e.g., GDP, Vaccination Rates).</li><li><b>Raw data:</b> Data coming directly from original data source or partner. Does not include any transformation.</li><li><b>Reference data:</b> A standard set of curated data that serve as the foundation for the IPM model.</li><li><b>Modeled Estimates:</b> Results that are outputs of a specific model.</li><li><b>Geospatial: </b>A spatial dataset or service.</li><li><b>Other:</b> Data that does not align with the other definitions.</li></ul>",
+      "examples": [
+        "{\"dataset_type\":\"survey\"}",
+        "{\"dataset_type\":\"indicator\"}",
+        "{\"dataset_type\":\"raw_data\"}",
+        "{\"dataset_type\":\"reference_data\"}",
+        "{\"dataset_type\":\"modeled_estimates\"}",
+        "{\"dataset_type\":\"geospatial\"}",
+        "{\"dataset_type\":\"other\"}"
+      ]
+    },
+    "version": { "title": "Version", "type": "string", "propertyOrder": 19 },
+    "methodology": {
+      "title": "Methodology",
+      "type": "string",
+      "propertyOrder": 20,
+      "description": "Methodology of how data was collected, created and/or any transformations performed on the data."
+    },
+    "dataset_date": {
+      "title": "Date of dataset",
+      "type": "string",
+      "propertyOrder": 21,
+      "description": "Date that the Dataset was created (not uploaded). Format is mm/dd/yyyy.",
+      "format": "date"
+    },
+    "expected_refresh_date": {
+      "title": "Expected date of next refresh",
+      "type": "string",
+      "propertyOrder": 22,
+      "format": "date"
+    },
+    "expected_update_frequency": {
+      "title": "Expected update frequency",
+      "type": "string",
+      "propertyOrder": 23,
+      "examples": [
+        "{\"expected_update_frequency\":\"weekly\"}",
+        "{\"expected_update_frequency\":\"monthly\"}",
+        "{\"expected_update_frequency\":\"semi_annually\"}",
+        "{\"expected_update_frequency\":\"annually\"}",
+        "{\"expected_update_frequency\":\"ad_hoc\"}",
+        "{\"expected_update_frequency\":\"other\"}"
+      ]
+    },
+    "usage_notes": {
+      "title": "Usage notes",
+      "type": "string",
+      "propertyOrder": 24,
+      "description": "Specific usage instructions on how the data in this Dataset should be used, any known issues with the data, and/or any other information that a user of the data might find helpful."
+    },
+    "investment_id": {
+      "title": "Investment ID",
+      "type": "string",
+      "propertyOrder": 25,
+      "description": "Used to store unique source system identifiers that come from a past, present or future investment system (e.g. opp1234)."
+    },
+    "internal_contact_point": {
+      "title": "Internal point of contact",
+      "type": "string",
+      "propertyOrder": 26,
+      "description": "Primary point of contact within the Foundation for the Dataset."
+    },
+    "locked": { "title": "Locked", "type": "string", "propertyOrder": 27 },
+    "data_privacy_regulated": {
+      "title": "Contains Personal Data?",
+      "type": "string",
+      "propertyOrder": 28,
+      "description": "Personal data is not currently supported in the Gates Data Exchange",
+      "examples": ["{\"data_privacy_regulated\":\"false\"}"]
+    },
+    "data_privacy_country": {
+      "title": "Country of Origin",
+      "type": "string",
+      "propertyOrder": 29,
+      "description": "Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values."
+    },
+    "data_privacy_state": {
+      "title": "US State of Origin",
+      "type": "string",
+      "propertyOrder": 30,
+      "description": "Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values."
+    },
+    "data_privacy_province": {
+      "title": "Canada Province of Origin",
+      "type": "string",
+      "propertyOrder": 31,
+      "description": "Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values."
+    },
+    "data_sharing_agreement": {
+      "title": "Data Sharing Agreement URL",
+      "type": "string",
+      "propertyOrder": 32
+    },
+    "data_expiration_date": {
+      "title": "Data Expiration Date",
+      "type": "string",
+      "propertyOrder": 33,
+      "description": "Format is mm/dd/yyyy",
+      "format": "date"
+    },
+    "guid": {
+      "title": "Remote dataset id",
+      "type": "string",
+      "propertyOrder": 34
+    },
+    "harvest_source_id": {
+      "title": "Harvest source id",
+      "type": "string",
+      "propertyOrder": 35
+    },
+    "harvest_source_url": {
+      "title": "Harvest source url",
+      "type": "string",
+      "propertyOrder": 36
+    },
+    "harvest_source_title": {
+      "title": "Harvest source title",
+      "type": "string",
+      "propertyOrder": 37
+    },
+    "harvest_timestamp": {
+      "title": "Harvest timestamp",
+      "type": "string",
+      "propertyOrder": 38
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "propertyOrder": 41
+    },
+    "format": { "title": "Format", "type": "string", "propertyOrder": 42 },
+    "file_encoding_type": {
+      "title": "File Encoding Type",
+      "type": "string",
+      "propertyOrder": 43,
+      "examples": [
+        "{\"file_encoding_type\":\"utf_8\"}",
+        "{\"file_encoding_type\":\"iso_8859_1\"}",
+        "{\"file_encoding_type\":\"windows_1251\"}",
+        "{\"file_encoding_type\":\"windows_1252\"}",
+        "{\"file_encoding_type\":\"shift_jis\"}",
+        "{\"file_encoding_type\":\"gb2312\"}",
+        "{\"file_encoding_type\":\"euc_kr\"}",
+        "{\"file_encoding_type\":\"iso_8859_2\"}",
+        "{\"file_encoding_type\":\"windows_1250\"}",
+        "{\"file_encoding_type\":\"euc_jp\"}",
+        "{\"file_encoding_type\":\"gbk\"}",
+        "{\"file_encoding_type\":\"big5\"}",
+        "{\"file_encoding_type\":\"iso_8859_15\"}",
+        "{\"file_encoding_type\":\"windows_1256\"}",
+        "{\"file_encoding_type\":\"iso_8859_9\"}"
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "notes",
+    "license_id",
+    "owner_org",
+    "information_classification",
+    "visibility",
+    "maintainer",
+    "maintainer_email",
+    "publisher",
+    "geographic_level",
+    "data_privacy_regulated",
+    "data_privacy_country",
+    "data_privacy_state",
+    "data_privacy_province"
+  ]
+}

--- a/test/fixtures/ckan-schema.json
+++ b/test/fixtures/ckan-schema.json
@@ -1,0 +1,579 @@
+{
+    "scheming_version": 1,
+    "dataset_type": "dataset",
+    "about": "BMGF's special metadatas",
+    "about_url": "http://github.com/ckan/ckanext-scheming",
+    "dataset_fields": [
+      {
+        "section": "Basic Metadata",
+        "field_name": "title",
+        "label": "Title",
+        "preset": "title",
+        "validators": "if_empty_same_as(name) unicode",
+        "form_placeholder": "A descriptive title",
+        "form_snippet": "text.html",
+        "form_attrs": {
+          "data-module": "slug-preview-target",
+          "class": "form-control harvest-field"
+        },
+        "help_text": "A descriptive name given to the Dataset. This should be an intuitive labelling of the Dataset for search, sharing and linking."
+      },
+      {
+        "field_name": "name",
+        "label": "URL",
+        "preset": "dataset_slug",
+        "form_placeholder": "my-dataset",
+        "required": true
+      },
+      {
+        "field_name": "notes",
+        "label": "Description",
+        "form_snippet": "markdown.html",
+        "form_placeholder": "Some useful notes about the data",
+        "form_attrs": {
+          "class": "form-control harvest-field"
+        },
+        "validators": "not_empty",
+        "required": true
+      },
+      {
+        "field_name": "tag_string",
+        "label": "Tags",
+        "preset": "tag_string_autocomplete",
+        "form_placeholder": "Population estimates, disease burden, etc",
+        "form_attrs": {
+          "data-module": "autocomplete",
+          "data-module-tags": "",
+          "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?",
+          "class": "form-control harvest-field"
+        },
+        "help_text": "What labels the Dataset in question belongs to. Tags also allow for browsing between similarly tagged Datasets in addition to enabling better discoverability through tag search."
+      },
+      {
+        "field_name": "license_id",
+        "label": "License",
+        "validators": "not_empty gdx_license_validator",
+        "form_snippet": "license.html",
+        "help_text": "Licenses makes it clear to users whether they have the rights to use, change and re-distribute the data. Definitions and additional information can be found at <a href=\"http://opendefinition.org/\" target=\"opendefinition.org\">http://opendefinition.org/</a>.",
+        "required": true
+      },
+      {
+        "field_name": "owner_org",
+        "label": "Organization",
+        "validators": "ignore_missing gdx_owner_org_validator unicode",
+        "preset": "dataset_organization",
+        "required": true,
+        "help_text": "The Team to which the Dataset belongs."
+      },
+      {
+        "field_name": "information_classification",
+        "label": "Information classification",
+        "validators": "not_empty",
+        "preset": "select",
+        "form_placeholder": "Choose one",
+        "option_help": true,
+        "help_text": "BMGF <a href=\"https://bmgf.sharepoint.com/:w:/r/sites/AzureCoP/_layouts/15/Doc.aspx?sourcedoc=%7BFFAA18FA-5297-45BE-B083-05BA6F5E925E%7D&file=Governance%20and%20Security%20-%20Information%20Classification%20Standard.docx&action=default&mobileredirect=true\" target=\"bmgf_pii\">Information Classification Standard</a>.",
+        "required": true,
+        "choices": [
+          {
+            "value": "public-public-external",
+            "label": "Public / Publicly-available Information / External",
+            "help_text": "Third party information that is legally available to the public or foundation information that is, or will be made, available to the public."
+          },
+          {
+            "value": "not_sensitive-non_confidential-internal-business",
+            "label": "Not Sensitive / Non-confidential Information / Internal / Business Decision",
+            "help_text": "Certain third-party information (e.g., work-related contact information) or foundation information (e.g., non-sensitive communications, policies, guidance documents, etc.) not available to the public or intended to be made available to the public but for which disclosure presents little to no risk."
+          },
+          {
+            "value": "not_sensitive-non_confidential-internal_limited_external-business",
+            "label": "Not Sensitive / Non-confidential Information / Internal and Limited External / Business Decision",
+            "help_text": "Certain foundation and third-party information intended to be shared between, and/or co-developed with, the third party (e.g., grantee or vendor)."
+          },
+          {
+            "value": "sensitive-confidential-internal_restricted-business",
+            "label": "Sensitive / Confidential Foundation Information / Internal - Restricted / Business Decision",
+            "help_text": "Certain foundation information (e.g., sensitive communications, ELT travel plans, GPA/Communication strategies, partner assessments, information, polices, guidance documents, etc.)."
+          },
+          {
+            "value": "sensitive-confidential_third_party-internal_restricted-agreement",
+            "label": "Sensitive / Confidential third-party information / Internal - Restricted / Agreement",
+            "help_text": "Certain third-party information disclosed pursuant to an NDA (e.g., vendor rates, costing information)."
+          },
+          {
+            "value": "sensitive-regulated-internal_restricted-regulation",
+            "label": "Sensitive / Regulated information / Internal - Restricted / Regulation",
+            "help_text": "Information protected by law/regulation (e.g., personal contact information)."
+          },
+          {
+            "value": "very_sensitive-highly_regulated-internal_highly_restricted-regulation",
+            "label": "Very Sensitive / Highly Regulated Information / Internal - Highly Restricted / Regulation",
+            "help_text": "Information protected by law/regulation (e.g., PHI, Student Records, Material Non-Public Information with high risk resulting from noncompliance or unauthorized disclosure). "
+          }
+        ]
+      },
+      {
+        "field_name": "visibility",
+        "label": "Visibility",
+        "validators": "not_missing visibility_validator",
+        "preset": "select",
+        "display_snippet": null,
+        "form_placeholder": "Choose one",
+        "form_attrs": {
+          "class": "form-control harvest-field"
+        },
+        "required": true,
+        "option_help": true,
+        "help_text": "The accessibility setting for the Dataset’s Resources, users can choose between the following: </br> <ul><li><b>Public</b>: Dataset’s Resources can be accessed by all users within the Foundation.</li><li><b>Restricted:</b> Restricted Datasets are visible to all foundation Users but can only be Explored (previewed or downloaded) by Members of the Team that the Dataset is associated with or Users that are Collaborators of the Dataset.</li></ul>",
+        "choices": [
+          {
+            "value": "restricted",
+            "label": "Restricted",
+            "help_text": "Restricted Datasets are visible to all foundation Users but can only be Explored (previewed or downloaded) by Members of the Team that the Dataset is associated with or Users that are Collaborators of the Dataset."
+          },
+          {
+            "value": "public",
+            "label": "Public",
+            "help_text": "Public Datasets are visible and can be Explored (previewed and downloaded) by all foundation Users."
+          }
+        ]
+      },
+      {
+        "field_name": "private",
+        "label": "Visibility (Private/Public)",
+        "validators": "always_false_if_not_sysadmin",
+        "form_snippet": null,
+        "display_snippet": null,
+        "help_text": "HELP TEXT FOR VISIBILITY"
+      },
+      {
+        "field_name": "maintainer",
+        "label": "Maintainer",
+        "validators": "not_empty gdx_maintainer_validator",
+        "form_snippet": "maintainer.html",
+        "form_placeholder": "John Doe",
+        "display_property": "dc:contributor",
+        "display_snippet": null,
+        "required": true,
+        "help_text": "The individual responsible for maintaining the Dataset."
+      },
+      {
+        "field_name": "maintainer_email",
+        "label": "Maintainer",
+        "validators": "gdx_maintainer_email_validator",
+        "form_snippet": null,
+        "form_placeholder": "john.doe@gatesfoundation.org",
+        "display_property": "dc:contributor",
+        "display_snippet": "maintainer_email.html",
+        "display_email_name_field": "maintainer",
+        "required": true
+      },
+      {
+        "field_name": "publisher",
+        "label": "Publisher",
+        "validators": "not_empty",
+        "form_placeholder": "Who, John Doe, etc",
+        "required": true,
+        "help_text": "An entity responsible for making the Dataset available. Examples of a Publisher include a person, an organization, or a service."
+      },
+      {
+        "field_name": "temporal_coverage",
+        "validators": "ignore_missing",
+        "label": "Temporal coverage",
+        "form_placeholder": "Year 2018",
+        "help_text": "The temporal topic of the Dataset. Temporal topic may be a named period, date, or date range."
+      },
+      {
+        "field_name": "geographic_coverage",
+        "validators": "ignore_missing",
+        "label": "Geographic coverage",
+        "form_placeholder": "tag#1, tag#2",
+        "preset": "tag_string_autocomplete",
+        "display_snippet": "list_items.html",
+        "vocabulary": "geographic_coverages",
+        "help_text": "Geographical area where data was collected or place which is the subject of a collection, or a location which is the focus of the Dataset."
+      },
+      {
+        "field_name": "geographic_level",
+        "label": "Geographic level",
+        "validators": "not_empty",
+        "preset": "select",
+        "form_placeholder": "Choose one",
+        "required": true,
+        "help_text": "The lowest level-of-detail/granularity of the Dataset along the geographic dimension.",
+        "choices": [
+          {
+            "value": "global",
+            "label": "Global"
+          },
+          {
+            "value": "regional",
+            "label": "Regional"
+          },
+          {
+            "value": "national",
+            "label": "National"
+          },
+          {
+            "value": "sub_national",
+            "label": "Sub-National"
+          },
+          {
+            "value": "other",
+            "label": "Other"
+          }
+        ]
+      },
+      {
+        "field_name": "language",
+        "label": "Language",
+        "preset": "tag_string_autocomplete",
+        "display_snippet": "list_items.html",
+        "vocabulary": "languages",
+        "help_text": "The language(s) of the Dataset."
+      },
+      {
+        "field_name": "url",
+        "label": "Source",
+        "form_placeholder": "http://example.com/dataset.json",
+        "display_property": "foaf:homepage",
+        "display_snippet": "link_if_url.html",
+        "help_text": "A related resource from which the described Dataset is derived. An example could be the website or a link to another Dataset/Resource."
+      },
+      {
+        "field_name": "dataset_type",
+        "label": "Type",
+        "preset": "select",
+        "form_placeholder": "Choose one",
+        "help_text": "The nature or genre of the Dataset. Users can choose between the following:</br> <ul><li><b>Survey:</b> An investigation about the characteristics of a given population by means of collecting data from a sample of that population.</li><li><b>Indicator: </b>Data that represents the measurement of something (e.g., GDP, Vaccination Rates).</li><li><b>Raw data:</b> Data coming directly from original data source or partner. Does not include any transformation.</li><li><b>Reference data:</b> A standard set of curated data that serve as the foundation for the IPM model.</li><li><b>Modeled Estimates:</b> Results that are outputs of a specific model.</li><li><b>Geospatial: </b>A spatial dataset or service.</li><li><b>Other:</b> Data that does not align with the other definitions.</li></ul>",
+        "choices": [
+          {
+            "value": "survey",
+            "label": "Survey"
+          },
+          {
+            "value": "indicator",
+            "label": "Indicator"
+          },
+          {
+            "value": "raw_data",
+            "label": "Raw data"
+          },
+          {
+            "value": "reference_data",
+            "label": "Reference data"
+          },
+          {
+            "value": "modeled_estimates",
+            "label": "Modeled estimates"
+          },
+          {
+            "value": "geospatial",
+            "label": "Geospatial"
+          },
+
+          {
+            "value": "other",
+            "label": "Other"
+          }
+        ]
+      },
+      {
+        "field_name": "version",
+        "label": "Version",
+        "validators": "ignore_missing gdx_version",
+        "form_placeholder": "1.0"
+      },
+      {
+        "field_name": "methodology",
+        "label": "Methodology",
+        "form_snippet": "markdown.html",
+        "display_snippet": null,
+        "form_placeholder": "Some useful notes about the methodology",
+        "help_text": "Methodology of how data was collected, created and/or any transformations performed on the data."
+      },
+      {
+        "field_name": "dataset_date",
+        "validators": "ignore_missing gdx_date",
+        "label": "Date of dataset",
+        "form_placeholder": "24/01/2018",
+        "form_attrs": {
+          "class": "form-control harvest-field"
+        },
+        "preset": "date",
+        "help_text": "Date that the Dataset was created (not uploaded). Format is mm/dd/yyyy."
+      },
+      {
+        "field_name": "expected_refresh_date",
+        "label": "Expected date of next refresh",
+        "validators": "ignore_missing gdx_date",
+        "form_placeholder": "24/01/2018",
+        "preset": "date"
+      },
+      {
+        "field_name": "expected_update_frequency",
+        "label": "Expected update frequency",
+        "preset": "select",
+        "form_placeholder": "Choose one",
+        "choices": [
+          {
+            "value": "weekly",
+            "label": "Weekly"
+          },
+          {
+            "value": "monthly",
+            "label": "Monthly"
+          },
+          {
+            "value": "semi_annually",
+            "label": "Semi-Annually"
+          },
+          {
+            "value": "annually",
+            "label": "Annually"
+          },
+          {
+            "value": "ad_hoc",
+            "label": "Ad-hoc"
+          },
+          {
+            "value": "other",
+            "label": "Other"
+          }
+        ]
+      },
+      {
+        "field_name": "usage_notes",
+        "label": "Usage notes",
+        "form_snippet": "markdown.html",
+        "display_snippet": null,
+        "form_placeholder": "Some usage notes...",
+        "form_attrs": {
+          "class": "form-control harvest-field"
+        },
+        "help_text": "Specific usage instructions on how the data in this Dataset should be used, any known issues with the data, and/or any other information that a user of the data might find helpful."
+      },
+      {
+        "field_name": "investment_id",
+        "validators": "ignore_missing",
+        "label": "Investment ID",
+        "preset": "tag_string_autocomplete",
+        "display_snippet": "list_items.html",
+        "vocabulary": "investment_ids",
+        "help_text": "Used to store unique source system identifiers that come from a past, present or future investment system (e.g. opp1234)."
+      },
+      {
+        "field_name": "internal_contact_point",
+        "validators": "ignore_missing",
+        "label": "Internal point of contact",
+        "form_placeholder": "John Doe",
+        "help_text": "Primary point of contact within the Foundation for the Dataset."
+      },
+      {
+        "field_name": "locked",
+        "validators": "boolean_validator gdx_team_admin_or_sysadmin_validator",
+        "output_validators": "boolean_validator",
+        "label": "Locked",
+        "default": true,
+        "display_snippet": null,
+        "form_snippet": null
+      },
+      {
+        "section": "Data Privacy and Sharing",
+        "section_subtitle": "Only applies to data that is uploaded to the Gates Data Exchange",
+        "field_name": "data_privacy_regulated",
+        "label": "Contains Personal Data?",
+        "validators": "boolean_validator gdx_always_false",
+        "output_validators": "boolean_validator",
+        "preset": "select",
+        "classes": ["control-medium"],
+        "form_attrs": {"data-module": "privacy-fields", "class": "form-control", "disabled": "disabled"},
+        "required": true,
+        "display_snippet": "boolean_yes_no.html",
+        "help_text": "Personal data is not currently supported in the Gates Data Exchange",
+        "choices": [
+          {
+            "value": "false",
+            "label": "No"
+          }
+        ]
+      },
+      {
+        "field_name": "data_privacy_country",
+        "label": "Country of Origin",
+        "preset": "multiple_select",
+        "select_size": 10,
+        "classes": ["control-medium", "label4"],
+        "validators": "gdx_not_missing_if_privacy_regulated gdx_country_code gdx_dump_json",
+        "output_validators": "scheming_load_json",
+        "form_placeholder": "Choose one",
+        "choices_helper": "gdx_get_privacy_countries",
+        "help_text": "Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values.",
+        "required": true
+      },
+      {
+        "field_name": "data_privacy_state",
+        "label": "US State of Origin",
+        "preset": "multiple_select",
+        "select_size": 10,
+        "classes": ["control-medium", "label4"],
+        "validators": "gdx_not_missing_if_usa gdx_us_state_code gdx_dump_json",
+        "output_validators": "scheming_load_json",
+        "form_placeholder": "Choose one",
+        "choices_helper": "gdx_get_privacy_states",
+        "help_text": "Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values.",
+        "required": true
+      },
+      {
+        "field_name": "data_privacy_province",
+        "label": "Canada Province of Origin",
+        "preset": "multiple_select",
+        "select_size": 10,
+        "classes": ["control-medium", "label4"],
+        "validators": "gdx_not_missing_if_canada gdx_canada_province_code gdx_dump_json",
+        "output_validators": "scheming_load_json",
+        "form_placeholder": "Choose one",
+        "choices_helper": "gdx_get_privacy_provinces",
+        "help_text": "Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values.",
+        "required": true
+      },
+      {
+        "field_name": "data_sharing_agreement",
+        "label": "Data Sharing Agreement URL",
+        "classes": ["control-medium"],
+        "input_type": "url",
+        "display_snippet": "link.html"
+      },
+      {
+        "field_name": "data_expiration_date",
+        "label": "Data Expiration Date",
+        "form_placeholder": "24/01/2018",
+        "classes": ["control-medium"],
+        "preset": "date",
+        "help_text": "Format is mm/dd/yyyy"
+      },
+      {
+          "field_name": "guid",
+          "label": "Remote dataset id",
+          "form_snippet": "hidden.html",
+          "display_snippet": null
+      },
+      {
+          "field_name": "harvest_source_id",
+          "label": "Harvest source id",
+          "form_snippet": "hidden.html",
+          "display_snippet": null
+      },
+      {
+          "field_name": "harvest_source_url",
+          "label": "Harvest source url",
+          "form_snippet": "hidden.html",
+          "display_snippet": null
+      },
+      {
+          "field_name": "harvest_source_title",
+          "label": "Harvest source title",
+          "form_snippet": "hidden.html",
+          "display_snippet": null
+      },
+      {
+          "field_name": "harvest_timestamp",
+          "label": "Harvest timestamp",
+          "form_snippet": "hidden.html",
+          "display_snippet": null
+      }
+    ],
+    "resource_fields": [
+      {
+        "field_name": "url",
+        "label": "URL",
+        "preset": "resource_url_upload",
+        "validators": "gdx_upload_and_url_not_empty"
+      },
+      {
+        "field_name": "name",
+        "label": "Name",
+        "form_placeholder": "eg. January 2011 Gold Prices"
+      },
+      {
+        "field_name": "description",
+        "label": "Description",
+        "form_snippet": "markdown.html",
+        "form_placeholder": "Some useful notes about the data"
+      },
+      {
+        "field_name": "format",
+        "label": "Format",
+        "preset": "resource_format_autocomplete"
+      },
+      {
+        "field_name": "file_encoding_type",
+        "label": "File Encoding Type",
+        "preset": "select",
+        "validators": "ignore_missing",
+        "form_placeholder": "Choose one",
+        "choices": [
+          {
+            "value": "utf_8",
+            "label": "UTF-8"
+          },
+          {
+            "value": "iso_8859_1",
+            "label": "ISO-8859-1"
+          },
+          {
+            "value": "windows_1251",
+            "label": "Windows-1251"
+          },
+          {
+            "value": "windows_1252",
+            "label": "Windows-1252"
+          },
+          {
+            "value": "shift_jis",
+            "label": "Shift JIS"
+          },
+          {
+            "value": "gb2312",
+            "label": "GB2312"
+          },
+          {
+            "value": "euc_kr",
+            "label": "EUC-KR"
+          },
+          {
+            "value": "iso_8859_2",
+            "label": "ISO-8859-2"
+          },
+          {
+            "value": "windows_1250",
+            "label": "Windows-1250"
+          },
+          {
+            "value": "euc_jp",
+            "label": "EUC-JP"
+          },
+          {
+            "value": "gbk",
+            "label": "GBK"
+          },
+          {
+            "value": "big5",
+            "label": "Big5"
+          },
+          {
+            "value": "iso_8859_15",
+            "label": "ISO-8859-15"
+          },
+          {
+            "value": "windows_1256",
+            "label": "Windows-1256"
+          },
+          {
+            "value": "iso_8859_9",
+            "label": "ISO-8859-9"
+          }
+        ]
+      }
+    ]
+  }

--- a/test/fixtures/ckan-schema.md
+++ b/test/fixtures/ckan-schema.md
@@ -1,0 +1,315 @@
+# BMGF&#39;s special metadatas
+
+**(`object`)**
+
+## Title
+
+**(`string`)**
+
+A descriptive name given to the Dataset. This should be an intuitive labelling of the Dataset for search, sharing and linking.
+
+## Name
+
+**(`string`)**
+
+## Description
+
+**(`string`)**
+
+## Tags
+
+**(`string`)**
+
+What labels the Dataset in question belongs to. Tags also allow for browsing between similarly tagged Datasets in addition to enabling better discoverability through tag search.
+
+## License
+
+**(`string`)**
+
+Licenses makes it clear to users whether they have the rights to use, change and re-distribute the data. Definitions and additional information can be found at &lt;a href=&quot;http://opendefinition.org/&quot; target=&quot;opendefinition.org&quot;&gt;http://opendefinition.org/&lt;/a&gt;.
+
+## Organization
+
+**(`string`)**
+
+The Team to which the Dataset belongs.
+
+## Information classification
+
+**(`string`)**
+
+BMGF &lt;a href=&quot;https://bmgf.sharepoint.com/:w:/r/sites/AzureCoP/_layouts/15/Doc.aspx?sourcedoc=%7BFFAA18FA-5297-45BE-B083-05BA6F5E925E%7D&amp;file=Governance%20and%20Security%20-%20Information%20Classification%20Standard.docx&amp;action=default&amp;mobileredirect=true&quot; target=&quot;bmgf_pii&quot;&gt;Information Classification Standard&lt;/a&gt;.
+
+### Examples
+
+- `{"information_classification":"public-public-external"}`
+
+- `{"information_classification":"not_sensitive-non_confidential-internal-business"}`
+
+- `{"information_classification":"not_sensitive-non_confidential-internal_limited_external-business"}`
+
+- `{"information_classification":"sensitive-confidential-internal_restricted-business"}`
+
+- `{"information_classification":"sensitive-confidential_third_party-internal_restricted-agreement"}`
+
+- `{"information_classification":"sensitive-regulated-internal_restricted-regulation"}`
+
+- `{"information_classification":"very_sensitive-highly_regulated-internal_highly_restricted-regulation"}`
+
+## Visibility
+
+**(`string`)**
+
+The accessibility setting for the Dataset’s Resources, users can choose between the following: &lt;/br&gt; &lt;ul&gt;&lt;li&gt;&lt;b&gt;Public&lt;/b&gt;: Dataset’s Resources can be accessed by all users within the Foundation.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Restricted:&lt;/b&gt; Restricted Datasets are visible to all foundation Users but can only be Explored (previewed or downloaded) by Members of the Team that the Dataset is associated with or Users that are Collaborators of the Dataset.&lt;/li&gt;&lt;/ul&gt;
+
+### Examples
+
+- `{"visibility":"restricted"}`
+
+- `{"visibility":"public"}`
+
+## Visibility (Private/Public)
+
+**(`string`)**
+
+HELP TEXT FOR VISIBILITY
+
+## Maintainer
+
+**(`string`)**
+
+The individual responsible for maintaining the Dataset.
+
+## Maintainer
+
+**(`string`)**
+
+## Publisher
+
+**(`string`)**
+
+An entity responsible for making the Dataset available. Examples of a Publisher include a person, an organization, or a service.
+
+## Temporal coverage
+
+**(`string`)**
+
+The temporal topic of the Dataset. Temporal topic may be a named period, date, or date range.
+
+## Geographic coverage
+
+**(`string`)**
+
+Geographical area where data was collected or place which is the subject of a collection, or a location which is the focus of the Dataset.
+
+## Geographic level
+
+**(`string`)**
+
+The lowest level-of-detail/granularity of the Dataset along the geographic dimension.
+
+### Examples
+
+- `{"geographic_level":"global"}`
+
+- `{"geographic_level":"regional"}`
+
+- `{"geographic_level":"national"}`
+
+- `{"geographic_level":"sub_national"}`
+
+- `{"geographic_level":"other"}`
+
+## Language
+
+**(`string`)**
+
+The language(s) of the Dataset.
+
+## URL
+
+**(`string`)**
+
+## Type
+
+**(`string`)**
+
+The nature or genre of the Dataset. Users can choose between the following:&lt;/br&gt; &lt;ul&gt;&lt;li&gt;&lt;b&gt;Survey:&lt;/b&gt; An investigation about the characteristics of a given population by means of collecting data from a sample of that population.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Indicator: &lt;/b&gt;Data that represents the measurement of something (e.g., GDP, Vaccination Rates).&lt;/li&gt;&lt;li&gt;&lt;b&gt;Raw data:&lt;/b&gt; Data coming directly from original data source or partner. Does not include any transformation.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Reference data:&lt;/b&gt; A standard set of curated data that serve as the foundation for the IPM model.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Modeled Estimates:&lt;/b&gt; Results that are outputs of a specific model.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Geospatial: &lt;/b&gt;A spatial dataset or service.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Other:&lt;/b&gt; Data that does not align with the other definitions.&lt;/li&gt;&lt;/ul&gt;
+
+### Examples
+
+- `{"dataset_type":"survey"}`
+
+- `{"dataset_type":"indicator"}`
+
+- `{"dataset_type":"raw_data"}`
+
+- `{"dataset_type":"reference_data"}`
+
+- `{"dataset_type":"modeled_estimates"}`
+
+- `{"dataset_type":"geospatial"}`
+
+- `{"dataset_type":"other"}`
+
+## Version
+
+**(`string`)**
+
+## Methodology
+
+**(`string`)**
+
+Methodology of how data was collected, created and/or any transformations performed on the data.
+
+## Date of dataset
+
+**(`string`)**
+
+Date that the Dataset was created (not uploaded). Format is mm/dd/yyyy.
+
+## Expected date of next refresh
+
+**(`string`)**
+
+## Expected update frequency
+
+**(`string`)**
+
+### Examples
+
+- `{"expected_update_frequency":"weekly"}`
+
+- `{"expected_update_frequency":"monthly"}`
+
+- `{"expected_update_frequency":"semi_annually"}`
+
+- `{"expected_update_frequency":"annually"}`
+
+- `{"expected_update_frequency":"ad_hoc"}`
+
+- `{"expected_update_frequency":"other"}`
+
+## Usage notes
+
+**(`string`)**
+
+Specific usage instructions on how the data in this Dataset should be used, any known issues with the data, and/or any other information that a user of the data might find helpful.
+
+## Investment ID
+
+**(`string`)**
+
+Used to store unique source system identifiers that come from a past, present or future investment system (e.g. opp1234).
+
+## Internal point of contact
+
+**(`string`)**
+
+Primary point of contact within the Foundation for the Dataset.
+
+## Locked
+
+**(`string`)**
+
+## Contains Personal Data?
+
+**(`string`)**
+
+Personal data is not currently supported in the Gates Data Exchange
+
+### Example
+
+- `{"data_privacy_regulated":"false"}`
+
+## Country of Origin
+
+**(`string`)**
+
+Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values.
+
+## US State of Origin
+
+**(`string`)**
+
+Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values.
+
+## Canada Province of Origin
+
+**(`string`)**
+
+Multiple values are allowed. Use Ctrl + Click to select or de-select multiple values.
+
+## Data Sharing Agreement URL
+
+**(`string`)**
+
+## Data Expiration Date
+
+**(`string`)**
+
+Format is mm/dd/yyyy
+
+## Remote dataset id
+
+**(`string`)**
+
+## Harvest source id
+
+**(`string`)**
+
+## Harvest source url
+
+**(`string`)**
+
+## Harvest source title
+
+**(`string`)**
+
+## Harvest timestamp
+
+**(`string`)**
+
+## Description
+
+**(`string`)**
+
+## Format
+
+**(`string`)**
+
+## File Encoding Type
+
+**(`string`)**
+
+### Examples
+
+- `{"file_encoding_type":"utf_8"}`
+
+- `{"file_encoding_type":"iso_8859_1"}`
+
+- `{"file_encoding_type":"windows_1251"}`
+
+- `{"file_encoding_type":"windows_1252"}`
+
+- `{"file_encoding_type":"shift_jis"}`
+
+- `{"file_encoding_type":"gb2312"}`
+
+- `{"file_encoding_type":"euc_kr"}`
+
+- `{"file_encoding_type":"iso_8859_2"}`
+
+- `{"file_encoding_type":"windows_1250"}`
+
+- `{"file_encoding_type":"euc_jp"}`
+
+- `{"file_encoding_type":"gbk"}`
+
+- `{"file_encoding_type":"big5"}`
+
+- `{"file_encoding_type":"iso_8859_15"}`
+
+- `{"file_encoding_type":"windows_1256"}`
+
+- `{"file_encoding_type":"iso_8859_9"}`

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -62,6 +62,15 @@ test("Can render a CKAN schema to MarkDown", async (t) => {
     );
 });
 
+test("Can read from a JSON file", async (t) => {
+  const expected = await readFixture("data-resource.md");
+  engine("./test/fixtures/data-resource.json", { input: "json", output: "md" })
+    .then((result) => t.is(result, expected))
+    .catch((error) =>
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
+    );
+});
+
 test("Can render using a custom template", async (t) => {
   const input = await readFixture("data-resource.json");
   const expected = await readFixture("custom-template-output.md");
@@ -77,7 +86,19 @@ test("Engine throws an error when JSON is invalid", async (t) => {
   engine(input, { output: "md" })
     .then(() => t.fail("Expected JSON validation error."))
     .catch((error) => {
-      const expected = "Invalid JSON input.";
+      const expected =
+        "Path points to a non-existent file, or it is an invalid JSON input.";
+      const result = error.message.substr(0, expected.length);
+      t.is(result, expected);
+    });
+});
+
+test("Engine throws an error when file path is invalid", async (t) => {
+  engine("this-should-not-exist.json", { input: "json", output: "md" })
+    .then(() => t.fail("Expected JSON validation error."))
+    .catch((error) => {
+      const expected =
+        "Path points to a non-existent file, or it is an invalid JSON input.";
       const result = error.message.substr(0, expected.length);
       t.is(result, expected);
     });
@@ -149,15 +170,4 @@ test("Engine throws an error when both input and output are JSON", async (t) => 
         "Input and output set to JSON, no transformation needed."
       );
     });
-});
-
-test("Can read a JSON file with --file flag", async (t) => {
-  const file = "./test/fixtures/data-resource.json";
-  const expected = await readFixture("data-resource.md");
-  const input = null;
-  engine(input, { input: "json", file: file, output: "md" })
-    .then((result) => t.is(result, expected))
-    .catch((error) =>
-      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
-    );
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -42,6 +42,26 @@ test("Can render a JSON schema to Python", async (t) => {
     );
 });
 
+test("Can render a CKAN schema to JSON", async (t) => {
+  const input = await readFixture("ckan-schema.json");
+  const expected = await readFixture("ckan-schema-as-json-schema.json");
+  engine(input, { input: "ckan", output: "json" })
+    .then((result) => t.is(result, expected))
+    .catch((error) =>
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
+    );
+});
+
+test("Can render a CKAN schema to MarkDown", async (t) => {
+  const input = await readFixture("ckan-schema.json");
+  const expected = await readFixture("ckan-schema.md");
+  engine(input, { input: "ckan", output: "md" })
+    .then((result) => t.is(result, expected))
+    .catch((error) =>
+      t.fail(`Expected to render with no errors, but got:${showError(error)}`)
+    );
+});
+
 test("Can render using a custom template", async (t) => {
   const input = await readFixture("data-resource.json");
   const expected = await readFixture("custom-template-output.md");
@@ -67,7 +87,7 @@ test("Engine throws an error when output format is invalid", async (t) => {
   engine("sample input", { output: "go" })
     .then(() => t.fail("Expected a output format validation error."))
     .catch((error) => {
-      const expected = "go is not valid. Options are: html, md, py.";
+      const expected = "go is not valid. Options are: html, json, md, py.";
       const result = error.message.substr(0, expected.length);
       t.is(result, expected);
     });
@@ -116,6 +136,17 @@ test("Engine throws an error when it has both output and template", async (t) =>
       t.is(
         error.message,
         "The engine needs an output or a template (not both)."
+      );
+    });
+});
+
+test("Engine throws an error when both input and output are JSON", async (t) => {
+  engine("sample input", { output: "json", input: "json" })
+    .then(() => t.fail("Expected a validation error."))
+    .catch((error) => {
+      t.is(
+        error.message,
+        "Input and output set to JSON, no transformation needed."
       );
     });
 });


### PR DESCRIPTION
As documented in the new `README.md`, now with the flag `--input ckan` we can take CKAN Schema and show it as JSON Schema, MarkDown, and every other format. As the changes in this PR were somehow aligned with #14, I already merged that PR, resolved conflicts, added missing test cases, and refined the API (as I suggested there).

In sum, to transform CKAN Schema into JSON Schema:

```console
$ jsv my-ckan-schema.json --input ckan --output json > my-json-schema.json
```

Or we cna do directly from CKAN Schema to other formats, for example:

```console
$ jsv my-ckan-schema.json --input ckan > schema.md
$ cat my-ckan-schema.json | jsv --input ckan --output py > schema.py
```